### PR TITLE
M4: expose Service#logs public reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Assistant::Service#logs` public reader exposing the full log timeline
+  (info + warning + error) in insertion order. Callers no longer need to
+  reach into `@logs` via `instance_variable_get`. (M4, v1 plan)
+
 ## [0.1.0] - 2026-05-07
 
 ### Added

--- a/lib/assistant/service.rb
+++ b/lib/assistant/service.rb
@@ -8,6 +8,10 @@ module Assistant
   class Service
     include LogList
 
+    # Public reader for the full log timeline (info + warning + error), in
+    # insertion order. See docs/v1/02-features.md M4.
+    attr_reader :logs
+
     class << self
       include InputBuilder
 

--- a/test/assistant/service_test.rb
+++ b/test/assistant/service_test.rb
@@ -164,5 +164,46 @@ module Assistant
       assert_equal 1, service.result
       assert_equal 1, calls
     end
+
+    # ---- #logs reader (M4) ----
+
+    def test_logs_reader_returns_empty_array_on_fresh_service
+      assert_equal [], Assistant::Service.new.logs
+    end
+
+    def test_logs_reader_returns_all_levels_in_insertion_order
+      klass = Class.new(Assistant::Service) do
+        def validate
+          add_log(level: :info,    source: :validate, detail: :step1, message: 'ok')
+          add_log(level: :warning, source: :validate, detail: :step2, message: 'heads up')
+          add_log(level: :error,   source: :validate, detail: :step3, message: 'boom')
+        end
+
+        def execute = :ok
+      end
+
+      service = klass.new
+      service.run
+
+      assert_equal 3, service.logs.size
+      assert_equal %i[info warning error], service.logs.map(&:level)
+    end
+
+    def test_logs_reader_is_union_of_infos_warnings_errors
+      klass = Class.new(Assistant::Service) do
+        def validate
+          add_log(level: :info,    source: :validate, detail: :step1, message: 'ok')
+          add_log(level: :warning, source: :validate, detail: :step2, message: 'heads up')
+        end
+
+        def execute = :ok
+      end
+
+      service = klass.new
+      service.run
+
+      assert_equal((service.infos + service.warnings + service.errors).sort_by(&:object_id),
+                   service.logs.sort_by(&:object_id))
+    end
   end
 end


### PR DESCRIPTION
## Summary

Implements **M4** from the v1 plan (`docs/v1/02-features.md`).

Adds `attr_reader :logs` to `Assistant::Service`. Callers can now read the full log timeline (info + warning + error, in insertion order) without reaching into `@logs` via `instance_variable_get`.

## Changes

- `lib/assistant/service.rb` — `attr_reader :logs`.
- `test/assistant/service_test.rb` — three new cases:
  - `test_logs_reader_returns_empty_array_on_fresh_service`
  - `test_logs_reader_returns_all_levels_in_insertion_order`
  - `test_logs_reader_is_union_of_infos_warnings_errors`
- `CHANGELOG.md` — `[Unreleased]` → `### Added`.

## Verification

```
bundle exec rake test    # 41 runs, 118 assertions, 0 failures
bundle exec rubocop      # 16 files, no offenses
```

## Checklist

- [x] Failing-then-passing Minitest cases added.
- [x] CHANGELOG entry added under `[Unreleased]`.
- [x] No new runtime dependency.
- [x] Purely additive; no breaking change.

Refs: docs/v1/02-features.md M4, planning PR #131.