### PR TITLE
plan: add M12 (keyword args for every method) to v1 roadmap

### DIFF
--- a/docs/v1/01-api-surface.md
+++ b/docs/v1/01-api-surface.md
@@ -35,8 +35,8 @@ Defined in `lib/assistant/service.rb:8`.
 | Signature                                          | Stability | Source                              |
 |----------------------------------------------------|-----------|-------------------------------------|
 | `Service.run(**inputs) -> Hash`                    | Frozen    | `lib/assistant/service.rb:14`       |
-| `Service.input(name, type:, required: false, if: nil, default: nil, allow_nil: false)` | Frozen | `lib/assistant/input_builder.rb:20` |
-| `Service.inputs(names, type:, **options)`          | Frozen    | `lib/assistant/input_builder.rb:13` |
+| `Service.input(name:, type:, required: false, if: nil, default: nil, allow_nil: false)` | Frozen | `lib/assistant/input_builder.rb:20` |
+| `Service.inputs(names:, type:, **options)`         | Frozen    | `lib/assistant/input_builder.rb:13` |
 
 > The `default:` and `allow_nil:` keys are **new in 1.0** — see
 > [`02-features.md`](./02-features.md).
@@ -122,7 +122,7 @@ Defined in `lib/assistant/log_list.rb:5`. Mixed into `Assistant::Service`.
 | Signature                                              | Stability | Source                              |
 |--------------------------------------------------------|-----------|-------------------------------------|
 | `#add_log(level:, source:, detail:, message:, trace: nil)` | Frozen | `lib/assistant/log_list.rb:6`       |
-| `#merge_logs(other_logs)`                              | Frozen    | `lib/assistant/log_list.rb:10`      |
+| `#merge_logs(logs:)`                                   | Frozen    | `lib/assistant/log_list.rb:10`      |
 | `#log_item_error_initialize(attr_name:, message:)`     | Frozen    | `lib/assistant/log_list.rb:16`      |
 | `#log_item_info(source:, detail:, message:, trace: nil)`    | Frozen *(new in 1.0)* | M5 in [`02-features.md`](./02-features.md) |
 | `#log_item_warning(source:, detail:, message:, trace: nil)` | Frozen *(new in 1.0)* | M5 in [`02-features.md`](./02-features.md) |
@@ -234,4 +234,5 @@ Labelled **Experimental** in 1.0 because the output format may evolve in
 | Result hash shape                                                                   | Frozen as-is     | No change; a `Result` value object is deferred to 2.x (Q1).                            |
 | `valid_required_*?` canonical name + `valid_require_*?` deprecation                 | **Breaking-soft** | M9 (Q2 decision). Old name still works in 1.x with `Kernel.warn`; removed in 2.0.      |
 | `LogItem.new` raises on invalid attrs                                               | **Breaking**     | M10 (Q8 decision). See [`06-migration-0x-to-1.md`](./06-migration-0x-to-1.md).         |
+| All methods keyword-only (`input name:`, `inputs names:`, `merge_logs logs:`)       | **Breaking**     | M12. See [`06-migration-0x-to-1.md`](./06-migration-0x-to-1.md).                       |
 | RBS canonical; Steep required day one                                               | Tooling          | Q6 decision.                                                                           |

--- a/docs/v1/02-features.md
+++ b/docs/v1/02-features.md
@@ -446,6 +446,118 @@ documented to avoid surprise.
 - **Owner**: _TBD_.
 - **Status**: `[ ]`.
 
+### M12. Keyword arguments for every public and internal method
+
+- **Rationale**: 0.1.0 is inconsistent about its calling convention. The
+  headline DSL (`Service.input`, `Service.inputs`) takes the attribute
+  name as a positional argument while every option after it is a
+  keyword. Internal helpers in `InputBuilder` follow the same mixed
+  pattern, and `LogList#merge_logs(other_logs)` is purely positional.
+  Mixed conventions make signatures harder to read, harder to type with
+  RBS (positional + keyword splats produce noisier sigs than pure
+  keyword ones), and harder to evolve — every new option that wants to
+  sit next to `attr_name` has to be a keyword anyway, so the positional
+  slot is a permanent wart. 1.0.0 is the only chance to land this
+  without a deprecation cycle (per Q-decision: 0.x EOL on 1.0.0 release
+  date), so it becomes a Must.
+- **API sketch**:
+  ```ruby
+  # Before (0.1.0)
+  class CreateUser < Assistant::Service
+    input  :role,        type: String, default: 'member'
+    inputs %i[a b c],    type: Integer, required: true
+  end
+
+  # After (1.0.0)
+  class CreateUser < Assistant::Service
+    input  name:  :role,        type: String, default: 'member'
+    inputs names: %i[a b c],    type: Integer, required: true
+  end
+  ```
+  Signature changes:
+  - `Service.input(attr_name, type:, **)` →
+    `Service.input(name:, type:, **)`.
+  - `Service.inputs(attr_names, type:, **)` →
+    `Service.inputs(names:, type:, **)`.
+  - `LogList#merge_logs(other_logs)` →
+    `LogList#merge_logs(logs:)`.
+  - All `InputBuilder` helpers
+    (`input_getter_meth(attr_name)`,
+    `input_checker_meth(attr_name)`,
+    `input_type_validator_meth(attr_name, type, **options)`,
+    `input_require_validator_meth(attr_name, **options)`,
+    `input_require_conditional_meth(attr_name, **options)`,
+    `type_validator_body(attr_name, types, allow_nil, message_builder)`,
+    `type_mismatch_message_builder(attr_name, types)`) become
+    fully keyword: `(name:)`, `(name:, type:, **options)`,
+    `(name:, types:, allow_nil:, message_builder:)`, etc.
+  - `LogItem#initialize`, `LogList#add_log`,
+    `LogList#log_item_error_initialize`, `LogList#log_item_*` shorthands
+    (added in M5), `Service.run`, and `Service#initialize` are already
+    keyword-only and do not change.
+- **Migration**: hard break. The 0.x → 1.0 migration guide
+  ([`06-migration-0x-to-1.md`](./06-migration-0x-to-1.md)) gets a
+  dedicated section with a `sed`-style recipe:
+  ```sh
+  # In a service file, rewrite every:
+  #   input :foo, ...
+  # to:
+  #   input name: :foo, ...
+  # and every:
+  #   inputs %i[a b c], ...
+  # to:
+  #   inputs names: %i[a b c], ...
+  ```
+  No runtime shim accepting the old positional form will be shipped —
+  this is the same hard-break policy used for M9 (`valid_require_*?`
+  removed in 2.0 after a deprecation cycle that we cannot run for M12
+  since the change is purely shape, not behaviour). The migration guide
+  notes that the change is `git grep`-able and trivially scriptable.
+- **Ordering**: lands **last** among the Must-list mechanical changes,
+  after M1–M11 and the four promoted Should items (M-S1..M-S4).
+  Reasons:
+  - It touches every test file in the suite (every `Class.new(Assistant::Service)`
+    fixture uses `input :foo, type: …`), so rebasing it on top of all
+    other input-related work avoids merge churn during M1/M2/M3/M7.
+  - It must come before M11 (RBS generator) so the generator emits sigs
+    against the final method shapes; otherwise the generator template
+    would need a rewrite.
+  - It must come before the Phase 4 docs sweep so the updated examples
+    use the new form throughout.
+- **Test plan**:
+  - Every existing test in `test/assistant/{service,input_builder,log_list,log_item}_test.rb`
+    is rewritten in the same PR to use the new keyword form; this is the
+    test that the change actually compiles and runs. Suite must remain
+    green with the same assertion count (no behaviour drift).
+  - New regression test in `test/assistant/input_builder_test.rb`:
+    calling `Service.input(:foo, type: String)` (old positional form)
+    raises `ArgumentError: missing keyword: :name`, asserting that no
+    accidental shim slipped in.
+  - New regression test for `LogList#merge_logs(other_logs)` raising
+    `ArgumentError: missing keyword: :logs`.
+- **Risk**: low semantically (no behaviour change), high mechanically
+  (every user file breaks). Mitigated by:
+  - Single, well-scoped PR that does only the rename — no behaviour
+    edits, no opportunistic refactors. Reviewers can read it as a pure
+    signature change.
+  - The migration guide entry shipping in the same PR.
+  - The 0.x EOL policy ([`04-release-checklist.md`](./04-release-checklist.md))
+    being clear that 1.0.0 is a breaking release and no 0.x patches
+    will follow.
+- **Docs touchpoint**:
+  - [`01-api-surface.md`](./01-api-surface.md) — update every signature in
+    the API surface table; add a "Changes vs. 0.1.0" entry: _"All
+    methods are keyword-only. `Service.input`/`Service.inputs` now take
+    `name:`/`names:` as a keyword."_
+  - [`06-migration-0x-to-1.md`](./06-migration-0x-to-1.md) — new
+    "Keyword-only method signatures" section with the sed recipe and an
+    explicit list of every renamed signature.
+  - [`03-documentation.md`](./03-documentation.md) — D2 (`guides/inputs.md`)
+    and the README quickstart examples updated to the new form during
+    Phase 4.
+- **Owner**: _TBD_.
+- **Status**: `[ ]`.
+
 ---
 
 ## Should (promoted to Must for 1.0)

--- a/docs/v1/06-migration-0x-to-1.md
+++ b/docs/v1/06-migration-0x-to-1.md
@@ -1,22 +1,41 @@
 <!-- markdownlint-disable MD013 MD024 -->
 # 06 — Migrating from 0.x to 1.0
 
-This document is the user-facing migration story. It is intentionally short
-because 1.0 is a **stabilisation** release: most users will upgrade with no
-code changes.
+This document is the user-facing migration story. 1.0 is a
+**stabilisation** release, but it ships three small breaking changes
+that every user has to address (see B1, B2, B3 below). Each of the
+three is mechanical and `git grep`-able.
 
 ## TL;DR
 
-If your app does **all** of the following, you can upgrade by bumping the
-constraint in your `Gemfile` to `gem 'assistant', '~> 1.0'`:
+Bump the constraint in your `Gemfile` to `gem 'assistant', '~> 1.0'`,
+then run the following three mechanical rewrites across your code:
+
+1. **Inputs are keyword-only (B3, M12)**: rewrite every
+   `input :foo, type: X` to `input name: :foo, type: X`, every
+   `inputs %i[a b], type: X` to `inputs names: %i[a b], type: X`,
+   and every `merge_logs(other.logs)` to
+   `merge_logs(logs: other.logs)`.
+2. **`LogItem.new` raises on invalid attrs (B1, M10)**: audit any
+   direct `LogItem.new(...)` call sites you have; the gem's own call
+   sites are already correct. Test fixtures that exercised the old
+   "constructs but `valid? == false`" path need updating.
+3. **`valid_require_*?` is deprecated (B2, M9)**: rename direct calls
+   to the new `valid_required_*?` form. Most users do not call these
+   predicates directly (they're driven internally by `validate_inputs`)
+   so no action is required for those users; the old name still works
+   in 1.x with a one-time `Kernel.warn` per call site.
+
+If your app does **all** of the following after those rewrites, no
+further changes are needed:
 
 - You only call `Service.run(...)` and read `:result`, `:status`,
   `:warnings`, `:errors` from the returned hash.
-- You declare inputs with `input :name, type: T` and optionally
+- You declare inputs with `input name: :foo, type: T` and optionally
   `required: true` and/or `if: ->(v) { ... }`.
 - You override `#execute` and (optionally) `#validate`.
 - You log via `add_log(level:, source:, detail:, message:)` with valid
-  attributes (see breaking-change note below).
+  attributes.
 - You inspect logs via `infos`, `warnings`, `errors` (the `LogList` mixin).
 
 ## Breaking changes (read first)
@@ -58,6 +77,60 @@ Two behavioural changes ship in 1.0 that may require code changes:
 - See M9 in [`02-features.md`](./02-features.md) and the entry in
   `docs/deprecations.md`.
 
+### B3. Keyword-only method signatures across the gem
+
+- **Before** (0.1.0): the DSL took the attribute name as a positional
+  argument, while every option was a keyword:
+  ```ruby
+  input  :role,        type: String, required: true
+  inputs %i[a b c],    type: Integer
+  log_list.merge_logs(other.logs)
+  ```
+- **After** (1.0.0): every public and internal method is keyword-only.
+  The attribute name is now passed as `name:` / `names:`, and
+  `LogList#merge_logs` takes `logs:`:
+  ```ruby
+  input  name:  :role,        type: String, required: true
+  inputs names: %i[a b c],    type: Integer
+  log_list.merge_logs(logs: other.logs)
+  ```
+- **Affected signatures**:
+  - `Service.input(attr_name, type:, **)` →
+    `Service.input(name:, type:, **)`.
+  - `Service.inputs(attr_names, type:, **)` →
+    `Service.inputs(names:, type:, **)`.
+  - `LogList#merge_logs(other_logs)` →
+    `LogList#merge_logs(logs:)`.
+  - All `InputBuilder` helpers
+    (`input_getter_meth`, `input_checker_meth`,
+    `input_type_validator_meth`, `input_require_validator_meth`,
+    `input_require_conditional_meth`, `type_validator_body`,
+    `type_mismatch_message_builder`) take their first argument as
+    `name:` (or `names:`/`types:` where appropriate). These are
+    documented as internal but are technically public on the class.
+  - `LogItem#initialize`, `LogList#add_log`,
+    `LogList#log_item_error_initialize`, `LogList#log_item_*`
+    shorthands, `Service.run`, and `Service#initialize` were already
+    keyword-only in 0.1.0 and are unchanged.
+- **Migration**: hard break, no runtime shim. The change is purely
+  mechanical and `git grep`-able. Recipe:
+  ```sh
+  # In each of your service files, rewrite:
+  #   input :foo, ...      ->  input name: :foo, ...
+  #   inputs %i[a b], ...  ->  inputs names: %i[a b], ...
+  #
+  # And anywhere you compose log lists:
+  #   foo.merge_logs(bar.logs)  ->  foo.merge_logs(logs: bar.logs)
+  ```
+  The old positional form raises `ArgumentError: missing keyword: :name`
+  immediately at class-definition time, so every miss is caught on the
+  first load — there are no silent runtime regressions.
+- **Rationale**: see M12 in [`02-features.md`](./02-features.md). Mixed
+  positional + keyword signatures complicate the RBS surface and the
+  M11 RBS generator template; pure-keyword signatures also leave room
+  to add further options to `input` without shuffling the positional
+  slot.
+
 ### Recipe: `bin/assistant-rbs` for Steep users
 
 If you use Steep against your services, run the new bundled CLI to
@@ -77,8 +150,8 @@ The generator is **Experimental** in 1.0; the output format may evolve in
 | Symbol                                          | 0.1.0                                                | 1.0.0                                                                                  | Action required                                |
 |-------------------------------------------------|------------------------------------------------------|----------------------------------------------------------------------------------------|------------------------------------------------|
 | `Assistant::VERSION`                            | `'0.1.0'` (`lib/assistant/version.rb:4`)             | `'1.0.0'`                                                                              | None.                                          |
-| `Service.input`                                 | `name`, `type:`, `required:`, `if:`                   | adds `default:` (M1), `allow_nil:` (M2), `type:` accepts an array (M3), `optional:` (M7) | None (back-compat additive).                   |
-| `Service.inputs`                                | unchanged                                            | unchanged                                                                              | None.                                          |
+| `Service.input`                                 | `name`, `type:`, `required:`, `if:`                   | `name:` is now a **keyword** (M12); adds `default:` (M1), `allow_nil:` (M2), `type:` accepts an array (M3), `optional:` (M7) | **Required**: `input :foo, type: X` → `input name: :foo, type: X`. See B3. |
+| `Service.inputs`                                | `names`, `type:`, `**options`                        | `names:` is now a **keyword** (M12)                                                    | **Required**: `inputs %i[a b], type: X` → `inputs names: %i[a b], type: X`. See B3. |
 | `Service#run` result hash                       | `{ result:, status:, warnings: }` / `{ errors:, result: nil, status: :with_errors }` | unchanged                                                          | None.                                          |
 | `Service#status` enum                           | `:ok`, `:with_warnings`, `:with_errors`              | unchanged                                                                              | None.                                          |
 | `Service#logs`                                  | not exposed; `instance_variable_get(:@logs)` only    | `attr_reader :logs` (M4)                                                               | Optional: replace any IVar peeks with `#logs`. |
@@ -91,6 +164,7 @@ The generator is **Experimental** in 1.0; the output format may evolve in
 | `Assistant.notifier=`                           | did not exist                                        | added (M-S3)                                                                           | Opt-in.                                        |
 | `Service#input_snapshot`                        | did not exist                                        | added (M-S4)                                                                           | Opt-in.                                        |
 | `bin/assistant-rbs` CLI                         | did not exist                                        | added (M11, Experimental)                                                              | Opt-in for Steep users.                        |
+| `LogList#merge_logs`                            | `merge_logs(other_logs)` positional                  | `merge_logs(logs:)` keyword-only (M12)                                                 | **Required**: `merge_logs(other.logs)` → `merge_logs(logs: other.logs)`. See B3. |
 | `lib/assistant/service.rbs`                     | empty class declaration                              | populated, Steep required in gem CI                                                    | If you ran Steep against 0.1.0, re-run; the new sig is more accurate. Use `bin/assistant-rbs` for your own services. |
 
 ## What you might want to clean up after upgrading

--- a/docs/v1/README.md
+++ b/docs/v1/README.md
@@ -50,6 +50,11 @@ recommendations:
 - **M11**: new bundled `bin/assistant-rbs` CLI generates per-class RBS
   signatures for user `Assistant::Service` subclasses; ships
   **Experimental** in 1.0 and **blocks** 1.0.0.
+- **M12**: every public and internal method becomes **keyword-only**
+  (breaking). `Service.input :foo, type: X` becomes
+  `Service.input name: :foo, type: X`; `LogList#merge_logs(other)`
+  becomes `#merge_logs(logs: other)`. Mechanical, `git grep`-able; no
+  runtime shim.
 - **Coverage**: target raised to ≥98% line / ≥95% branch but enforced as
   a **soft gate** (report only).
 - **PR granularity**: one PR per concern (~20 PRs total).


### PR DESCRIPTION
## Summary

Adds **M12** to the v1 Must list: every public and internal method in the gem becomes keyword-only.

```ruby
# Before (0.1.0)
input  :role,        type: String, required: true
inputs %i[a b c],    type: Integer
log_list.merge_logs(other.logs)

# After (1.0.0, M12)
input  name:  :role,        type: String, required: true
inputs names: %i[a b c],    type: Integer
log_list.merge_logs(logs: other.logs)
```

## Why a roadmap PR (not code)

This is a docs-only change to the planning workspace. It records the decision, places M12 in the right ordering slot (last among Must-list mechanical changes), and updates every cross-reference so the next time someone opens the API-surface or migration docs they see the new shape. The implementation PR comes later, after M1-M11 and M-S1..S4 land.

## Decision

- **Scope** (chosen): "Everything including DSL" — `Service.input`, `Service.inputs`, `LogList#merge_logs`, and all `InputBuilder` helpers.
- **Tier** (chosen): **Must, 1.0.0**.
- **Migration**: hard break, no runtime shim. `git grep`-able; old positional form raises `ArgumentError: missing keyword: :name` immediately at class-definition time, so every miss is caught on the first load.
- **Ordering**: lands last so it rebases cleanly on top of every other input-related change, and so M11 (RBS generator) emits sigs against the final method shapes.

## Changes

- `docs/v1/02-features.md` — new `### M12.` section between M11 and the Should heading; full rationale, API sketch, migration recipe, ordering rationale, test plan, risk, docs touchpoints.
- `docs/v1/01-api-surface.md`
  - `Service.input` and `Service.inputs` signatures updated to take `name:` / `names:` as keywords.
  - `LogList#merge_logs` row updated to `#merge_logs(logs:)`.
  - New row in the 'Changes vs. 0.1.0' table marked **Breaking** with link to migration guide.
- `docs/v1/06-migration-0x-to-1.md`
  - New `### B3. Keyword-only method signatures across the gem` section with full signature list and sed-style recipe.
  - Per-symbol diff table updated for `Service.input`, `Service.inputs`, `LogList#merge_logs`.
  - TL;DR rewritten to lead with the three required mechanical rewrites (B1/B2/B3) — 1.0.0 is no longer a zero-change upgrade for any user.
- `docs/v1/README.md` — at-a-glance bullet for M12 added below M11.

## Verification

```
grep -n '^### M' docs/v1/02-features.md   # M1..M12, M-S1..M-S4 all present
```

No code changes; no tests to run.

## Checklist

- [x] M12 sits between M11 and the `## Should` heading; M2-M11 and M-S1..S4 intact.
- [x] All cross-references updated (`01-api-surface.md`, `06-migration-0x-to-1.md`, `README.md`).
- [x] TL;DR in migration guide reflects that no user can upgrade without code changes.
- [x] No runtime code changes; no CHANGELOG entry needed yet (added in the implementation PR).

Refs: planning PR #131.