### PR TITLE
M9: deprecate valid_require_*? in favour of valid_required_*?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,12 +65,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Tests mirror the lib layout under `test/assistant/input_builder/`.
   Removes the temporary `Metrics/ModuleLength: Max: 150` override from
   `.rubocop.yml`. (M13, v1 plan)
+- For each `input :name, required: true` declaration, `Service` subclasses
+  now generate `#valid_required_<name>?` as the canonical requirement
+  validator (and `#valid_required_conditional_<name>?` when `if:` is also
+  given). The pre-existing `#valid_require_<name>?` / `#valid_require_conditional_<name>?`
+  predicates remain as deprecated aliases — they delegate to the
+  canonical method and emit a `Kernel.warn` once per textual call site
+  pointing at the canonical replacement. `Service#validate_inputs`
+  invokes only the canonical names, so internal framework code never
+  triggers the deprecation warning. See
+  [`docs/deprecations.md`](docs/deprecations.md). (M9, v1 plan)
 - `lib/assistant.rb` now requires every core building block explicitly in
   dependency order (`version`, `log_item`, `log_list`,
   `refinements/string_blankness`, `input_builder`, `service`). After a bare
   `require "assistant"`, `Assistant::LogList`, `Assistant::InputBuilder`, and
   `Assistant::Refinements::StringBlankness` are reachable without first
   loading `Assistant::Service`. (M6, v1 plan)
+
+### Deprecated
+
+- `Assistant::Service#valid_require_<name>?` (use
+  `#valid_required_<name>?` instead). Scheduled for removal in
+  `assistant 2.0`. (M9, v1 plan)
+- `Assistant::Service#valid_require_conditional_<name>?` (use
+  `#valid_required_conditional_<name>?` instead). Scheduled for removal
+  in `assistant 2.0`. (M9, v1 plan)
 
 ## [0.1.0] - 2026-05-07
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -1,0 +1,81 @@
+# Deprecations
+
+This page tracks every public symbol that is **deprecated** in a 1.x release
+and the version in which it will be removed. Each entry includes a 1:1
+replacement and the runtime warning users will see.
+
+The deprecation policy is one full minor cycle: anything marked here in
+`1.x` is removed in `2.0`.
+
+## Index
+
+| Symbol                                                  | Replacement                                                       | Deprecated in | Removed in |
+|---------------------------------------------------------|-------------------------------------------------------------------|---------------|------------|
+| `Assistant::Service#valid_require_<name>?`              | `Assistant::Service#valid_required_<name>?`                       | `1.0.0` (M9)  | `2.0.0`    |
+| `Assistant::Service#valid_require_conditional_<name>?`  | `Assistant::Service#valid_required_conditional_<name>?`           | `1.0.0` (M9)  | `2.0.0`    |
+
+---
+
+## `valid_require_<name>?` → `valid_required_<name>?`
+
+**Deprecated in**: `1.0.0` (M9). **Removed in**: `2.0.0`.
+
+### What changed
+
+Per-input requirement validators are now generated under their
+grammatically correct names. For each `input :name, required: true`
+declaration, `Assistant::Service` subclasses gain:
+
+| Canonical (use this)                          | Deprecated alias (still works, warns once per call site) |
+|-----------------------------------------------|----------------------------------------------------------|
+| `#valid_required_<name>?`                     | `#valid_require_<name>?`                                 |
+| `#valid_required_conditional_<name>?`         | `#valid_require_conditional_<name>?`                     |
+
+Both names refer to the same underlying predicate — the deprecated alias
+simply delegates to the canonical method after emitting the deprecation
+warning. Return values, side effects, and `log_item_error_initialize`
+behaviour are unchanged.
+
+### Runtime warning
+
+```text
+assistant: `#valid_require_email?` is deprecated; use `#valid_required_email?` (removed in assistant 2.0)
+```
+
+The warning fires through `Kernel.warn` (i.e. on `$stderr`) **once per
+textual call site** (`caller_locations(1, 1).first` is keyed by `path +
+lineno`). Calling the alias 100 times from the same line yields exactly
+one warning; calling it from two different lines yields two warnings.
+
+Internal framework code (`Service#validate_inputs`) calls only the
+canonical name, so the warning never fires from inside the gem.
+
+### Migration
+
+Search-and-replace at the call site:
+
+```ruby
+# Before
+service.valid_require_email?
+service.valid_require_conditional_token?
+
+# After
+service.valid_required_email?
+service.valid_required_conditional_token?
+```
+
+If your code overrides one of these predicates (`def valid_require_email?
+...`), rename the override to the canonical name. The deprecated alias
+will still exist in `1.x` and will continue to delegate to the canonical
+method, so an override under the old name is silently bypassed.
+
+### Why
+
+Q2 in
+[`docs/v1/07-risks-and-open-questions.md`](./v1/07-risks-and-open-questions.md)
+was decided in favour of Option B: the new names read better, match
+standard English, and are easier to grep for. The old names live one
+minor cycle to give downstream services an upgrade window.
+
+See [`docs/v1/02-features.md`](./v1/02-features.md) **M9** for the
+implementation plan and acceptance criteria.

--- a/docs/v1/02-features.md
+++ b/docs/v1/02-features.md
@@ -388,9 +388,10 @@ documented to avoid surprise.
   `lib/assistant/service.rb:54` migrate to the new name to avoid the
   warning.
 - **Docs touchpoint**: seed `docs/deprecations.md` with the first entry,
-  per D2 in [`03-documentation.md`](./03-documentation.md).
+  per D2 in [`03-documentation.md`](./03-documentation.md). Shipped with
+  M9: [`docs/deprecations.md`](../deprecations.md).
 - **Owner**: _TBD_.
-- **Status**: `[ ]`.
+- **Status**: `[x]` — shipped on `feature/m9-required-deprecation`.
 
 ### M10. `LogItem.new` raises on invalid construction
 

--- a/lib/assistant/input_builder/require_validator.rb
+++ b/lib/assistant/input_builder/require_validator.rb
@@ -1,13 +1,55 @@
 # frozen_string_literal: true
 
-# Generators for the per-input `valid_require_<name>?` and
-# `valid_require_conditional_<name>?` validators. Reads `:required`,
-# `:allow_nil` (M2), and `:if` from the input options.
+# Generators for the per-input requirement validators. Canonical names
+# (M9):
+#
+#   #valid_required_<name>?              # for `required: true`
+#   #valid_required_conditional_<name>?  # for `required: true, if: ...`
+#
+# Pre-M9 names (`valid_require_*?`, `valid_require_conditional_*?`) are
+# kept as deprecated aliases that delegate to the canonical method and
+# emit a one-shot `Kernel.warn` per call site. They are scheduled for
+# removal in `assistant 2.0`.
 module Assistant::InputBuilder::RequireValidator
-  def input_require_validator_meth(attr_name, **options)
+  # Guard so each deprecated alias warns at most once per textual call
+  # site (file + lineno), regardless of how many times it is invoked or
+  # how many input names are involved. Internal; tests reset it via
+  # `.send(:__reset_deprecation_warnings__)`.
+  DEPRECATION_WARNED = Set.new
+  private_constant :DEPRECATION_WARNED
+
+  def self.warn_deprecated(deprecated_name, canonical_name, caller_location)
+    key = [canonical_name, caller_location.path, caller_location.lineno]
+    return if DEPRECATION_WARNED.include?(key)
+
+    DEPRECATION_WARNED << key
+    Kernel.warn("assistant: `##{deprecated_name}` is deprecated; use `##{canonical_name}` (removed in assistant 2.0)")
+  end
+
+  # Test-only hook: clears the per-call-site dedupe set so a single
+  # test process can exercise multiple "first warn" scenarios.
+  def self.__reset_deprecation_warnings__
+    DEPRECATION_WARNED.clear
+  end
+
+  def input_require_validator_meth(attr_name, **)
+    canonical = :"valid_required_#{attr_name}?"
+    define_required_validator(canonical, attr_name, **)
+    define_deprecated_alias(:"valid_require_#{attr_name}?", canonical)
+  end
+
+  def input_require_conditional_meth(attr_name, **)
+    canonical = :"valid_required_conditional_#{attr_name}?"
+    define_required_conditional_validator(canonical, attr_name, **)
+    define_deprecated_alias(:"valid_require_conditional_#{attr_name}?", canonical)
+  end
+
+  private
+
+  def define_required_validator(canonical, attr_name, **options)
     allow_nil = options.fetch(:allow_nil, false) == true
 
-    define_method("valid_require_#{attr_name}?") do |log = true|
+    define_method(canonical) do |log = true|
       # M2: explicit nil counts as "supplied" when allow_nil: true is set.
       return true if allow_nil && @inputs.key?(attr_name)
       return true if options[:required] == true && send("#{attr_name}?") == true
@@ -19,9 +61,9 @@ module Assistant::InputBuilder::RequireValidator
     end
   end
 
-  def input_require_conditional_meth(attr_name, **options)
-    define_method("valid_require_conditional_#{attr_name}?") do
-      return false if send("valid_require_#{attr_name}?", false) == false
+  def define_required_conditional_validator(canonical, attr_name, **options)
+    define_method(canonical) do
+      return false if send(:"valid_required_#{attr_name}?", false) == false
       return true if options[:if].call(send(attr_name))
 
       send(
@@ -30,6 +72,13 @@ module Assistant::InputBuilder::RequireValidator
         message: "Service argument conditional requirement not met properly for #{attr_name}"
       )
       false
+    end
+  end
+
+  def define_deprecated_alias(deprecated, canonical)
+    define_method(deprecated) do |*args, **kwargs|
+      ::Assistant::InputBuilder::RequireValidator.warn_deprecated(deprecated, canonical, caller_locations(1, 1).first)
+      send(canonical, *args, **kwargs)
     end
   end
 end

--- a/lib/assistant/service.rb
+++ b/lib/assistant/service.rb
@@ -85,7 +85,12 @@ module Assistant
     end
 
     def validate_inputs
-      methods.grep(/valid_(require|type|require_conditional)_\w+\?$/).each do |validation_method|
+      # M9: regex matches only the canonical `valid_required_*?` /
+      # `valid_required_conditional_*?` / `valid_type_*?` predicates so
+      # the deprecated `valid_require_*?` aliases are not auto-invoked
+      # (which would emit the M9 deprecation warning from inside the
+      # framework itself).
+      methods.grep(/valid_(required|type)_\w+\?$/).each do |validation_method|
         send(validation_method)
       end
     end

--- a/test/assistant/input_builder/dsl_test.rb
+++ b/test/assistant/input_builder/dsl_test.rb
@@ -12,7 +12,7 @@ module Assistant::InputBuilder
 
       %i[a b c a? b? c?
          valid_type_a? valid_type_b? valid_type_c?
-         valid_require_a? valid_require_b? valid_require_c?].each do |meth|
+         valid_required_a? valid_required_b? valid_required_c?].each do |meth|
         assert_includes klass.instance_methods, meth
       end
     end

--- a/test/assistant/input_builder/optional_option_test.rb
+++ b/test/assistant/input_builder/optional_option_test.rb
@@ -24,6 +24,7 @@ module Assistant::InputBuilder
         input :nickname, type: String, optional: true
       end
 
+      refute_includes klass.instance_methods, :valid_required_nickname?
       refute_includes klass.instance_methods, :valid_require_nickname?
     end
 
@@ -33,7 +34,7 @@ module Assistant::InputBuilder
         def execute = email
       end
 
-      assert_includes klass.instance_methods, :valid_require_email?
+      assert_includes klass.instance_methods, :valid_required_email?
 
       outcome = klass.run
 

--- a/test/assistant/input_builder/require_validator_test.rb
+++ b/test/assistant/input_builder/require_validator_test.rb
@@ -4,6 +4,14 @@ require_relative '../../test_helper'
 
 module Assistant::InputBuilder
   class RequireValidatorTest < Minitest::Test
+    include TestHelpers::IoCapture
+
+    def setup
+      # Reset the per-call-site dedupe set so each test starts from a
+      # clean slate; otherwise the order tests run in would decide
+      # which one observes the first warn.
+      Assistant::InputBuilder::RequireValidator.__reset_deprecation_warnings__
+    end
     # ---- Conditional requirement ----
 
     def test_conditional_requirement_errors_when_missing
@@ -83,7 +91,119 @@ module Assistant::InputBuilder
         input_require_validator_meth(:foo, required: true)
       end
 
-      assert_includes klass.instance_methods, :valid_require_foo?
+      assert_includes klass.instance_methods, :valid_required_foo?
+    end
+
+    # ---- M9: canonical `valid_required_*?` names ----
+
+    def test_required_input_generates_canonical_required_predicate
+      klass = Class.new(Assistant::Service) do
+        input :email, type: String, required: true
+      end
+
+      assert_includes klass.instance_methods, :valid_required_email?
+    end
+
+    def test_required_conditional_input_generates_canonical_conditional_predicate
+      klass = Class.new(Assistant::Service) do
+        input :token, type: String, required: true, if: ->(v) { v.start_with?('sk-') }
+      end
+
+      assert_includes klass.instance_methods, :valid_required_conditional_token?
+    end
+
+    def test_optional_input_generates_neither_canonical_nor_deprecated_predicate
+      klass = Class.new(Assistant::Service) do
+        input :nickname, type: String
+      end
+
+      refute_includes klass.instance_methods, :valid_required_nickname?
+      refute_includes klass.instance_methods, :valid_require_nickname?
+    end
+
+    # ---- M9: deprecated `valid_require_*?` aliases ----
+
+    def test_deprecated_alias_is_still_generated_alongside_canonical
+      klass = Class.new(Assistant::Service) do
+        input :email, type: String, required: true
+      end
+
+      assert_includes klass.instance_methods, :valid_require_email?
+      assert_includes klass.instance_methods, :valid_required_email?
+    end
+
+    def test_deprecated_alias_returns_the_same_value_as_canonical
+      klass = Class.new(Assistant::Service) do
+        input :email, type: String, required: true
+      end
+
+      missing = klass.new
+
+      capture_io_warn do
+        assert_equal missing.valid_required_email?(false), missing.valid_require_email?(false)
+      end
+
+      present = klass.new(email: 'x@y')
+
+      capture_io_warn do
+        assert_equal present.valid_required_email?, present.valid_require_email?
+      end
+    end
+
+    def test_deprecated_alias_warns_once_per_call_site_with_canonical_pointer
+      klass = Class.new(Assistant::Service) do
+        input :email, type: String, required: true
+      end
+      instance = klass.new(email: 'x@y')
+
+      output = capture_io_warn do
+        3.times { instance.valid_require_email? } # same call site -> one warn
+      end
+
+      assert_equal 1, output.scan('deprecated').size, "got: #{output.inspect}"
+      assert_match(/valid_require_email\?/, output)
+      assert_match(/valid_required_email\?/, output)
+      assert_match(/removed in assistant 2\.0/, output)
+    end
+
+    def test_deprecated_alias_warns_again_from_a_distinct_call_site
+      klass = Class.new(Assistant::Service) do
+        input :email, type: String, required: true
+      end
+      instance = klass.new(email: 'x@y')
+
+      output = capture_io_warn do
+        instance.valid_require_email?
+        instance.valid_require_email?
+      end
+
+      assert_equal 2, output.scan('deprecated').size, "got: #{output.inspect}"
+    end
+
+    def test_deprecated_conditional_alias_warns_and_delegates
+      klass = Class.new(Assistant::Service) do
+        input :token, type: String, required: true, if: ->(v) { v.start_with?('sk-') }
+      end
+      instance = klass.new(token: 'sk-ok')
+
+      output = capture_io_warn do
+        assert_equal instance.valid_required_conditional_token?, instance.valid_require_conditional_token?
+      end
+
+      assert_match(/valid_require_conditional_token\?/, output)
+      assert_match(/valid_required_conditional_token\?/, output)
+    end
+
+    def test_service_run_does_not_emit_deprecation_warnings_for_internal_validation
+      klass = Class.new(Assistant::Service) do
+        input :email, type: String, required: true
+        input :token, type: String, required: true, if: ->(v) { v.start_with?('sk-') }
+        def execute = :ok
+      end
+
+      output = capture_io_warn { klass.run(email: 'x@y', token: 'sk-ok') }
+
+      refute_match(/deprecated/, output)
     end
   end
 end


### PR DESCRIPTION
## Summary

Generate **`#valid_required_<name>?`** and **`#valid_required_conditional_<name>?`** as the canonical per-input requirement validators on every `Assistant::Service` subclass. The pre-M9 spellings (`#valid_require_<name>?` / `#valid_require_conditional_<name>?`) stay one minor cycle as **deprecated aliases** that delegate to the canonical method and emit a one-shot `Kernel.warn` per textual call site. Removal target: `assistant 2.0`.

Resolves Q2 in [`docs/v1/07-risks-and-open-questions.md`](../blob/main/docs/v1/07-risks-and-open-questions.md). Implements M9 from [`docs/v1/02-features.md`](../blob/main/docs/v1/02-features.md).

## Rationale

The pre-M9 names read as imperative (`require`) where the surrounding API is declarative. The new spellings (`required` / `required_conditional`) match standard English, are easier to grep against the `required: true` DSL option, and reduce confusion when reading a `Service` from top to bottom. Q2 was decided in favour of Option B in the planning docs; this PR ships it.

## Scope

### Behaviour

For each `input :name, required: true` declaration on a `Service` subclass:

| Canonical (use this)                          | Deprecated alias (still works, warns once per call site) |
|-----------------------------------------------|----------------------------------------------------------|
| `#valid_required_<name>?`                   | `#valid_require_<name>?`                               |
| `#valid_required_conditional_<name>?`       | `#valid_require_conditional_<name>?`                   |

Both spellings reach the same predicate body. The alias is implemented as a thin `define_method` that:

1. Looks up the caller via `caller_locations(1, 1).first` (`path` + `lineno`).
2. Emits `Kernel.warn` **once per (canonical-name, path, lineno) triple**.
3. Forwards `*args, **kwargs` to the canonical method.

The dedupe Set lives on `Assistant::InputBuilder::RequireValidator` (`private_constant`); a test-only `__reset_deprecation_warnings__` hook keeps the suite deterministic.

### Warning format

```text
assistant: `#valid_require_email?` is deprecated; use `#valid_required_email?` (removed in assistant 2.0)
```

### Framework internals never trigger the warning

`Service#validate_inputs` regex tightened to `/valid_(required|type)_\\w+\\?$/` so the auto-validation loop hits only canonical predicates. `Service.run` produces zero deprecation noise.

### SRP refactor inside `RequireValidator`

The original `input_require_validator_meth` / `input_require_conditional_meth` orchestrators are now small wrappers around three private helpers:

- `define_required_validator(canonical, attr_name, **options)`
- `define_required_conditional_validator(canonical, attr_name, **options)`
- `define_deprecated_alias(deprecated, canonical)` — reusable, the only place that knows `caller_locations` + the Set.

This matches the M1/M7 `process_/validate_!/apply_` shape and keeps every public generator one screen tall.

## Tests

`bundle exec rake test` — **121 runs / 349 assertions / 0 failures** (was 112 / 318).

New assertions in `test/assistant/input_builder/require_validator_test.rb`:

- Canonical name generated for `required: true`.
- Canonical conditional name generated for `required: true, if: ...`.
- Optional input generates **neither** canonical nor deprecated alias.
- Deprecated alias is still generated alongside canonical.
- Deprecated alias returns the same value as canonical (missing + present cases).
- Deprecated alias warns exactly once per call site (3× from one line → 1 warning).
- Deprecated alias warns again from a distinct call site (2 lines → 2 warnings).
- Deprecated conditional alias delegates + warns.
- `Service.run` emits zero deprecation warnings for internal validation.

Existing tests in `optional_option_test.rb`, `dsl_test.rb`, `require_validator_test.rb` updated to assert against canonical names; opt-out tests strengthened to assert **both** spellings are absent.

## Tooling

`bundle exec rubocop` — **30 files inspected, no offenses detected**.

## Docs

- **New** [`docs/deprecations.md`](../blob/feature/m9-required-deprecation/docs/deprecations.md): seeded with policy (1.x deprecation → 2.0 removal), index table, the exact warning string, migration snippet, and rationale link. Satisfies D2 in `docs/v1/03-documentation.md`.
- `docs/v1/02-features.md` M9 entry flipped to `[x]` with a back-reference to the new deprecations page.
- `CHANGELOG.md` `[Unreleased]` gains a `### Deprecated` block listing both alias families with the removal target.

## Migration

```ruby
# Before
service.valid_require_email?
service.valid_require_conditional_token?

# After
service.valid_required_email?
service.valid_required_conditional_token?
```

No-op if you only call these predicates indirectly via `Service.run` — the framework already uses the canonical names.

## Risk

Low. The deprecated aliases preserve the full pre-M9 contract (return value, argument list, side effects on `@logs`). The only observable change for unmigrated callers is a single `$stderr` line per call site.