### PR TITLE
M10: raise on invalid LogItem construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `Assistant::LogItem.new` now raises `ArgumentError` when constructed with
+  invalid attributes instead of returning an invalid object. Validation runs at
+  the end of initialization and reports every failing attribute in one message
+  (level, source, detail, message). The `#valid?` predicate family remains for
+  introspection and returns `true` for normally constructed instances.
+  `LogList#add_log` now inherits this fail-fast behaviour because it constructs
+  `LogItem` internally. (M10, v1 plan)
 - `Assistant::InputBuilder` split into per-concern submodules under
   `lib/assistant/input_builder/` (`Registry`, `DefaultOption`,
   `OptionalOption`, `Accessors`, `RequireValidator`, `TypeValidator`,

--- a/docs/v1/02-features.md
+++ b/docs/v1/02-features.md
@@ -421,7 +421,7 @@ documented to avoid surprise.
   ensure validity. Documented as breaking in
   [`06-migration-0x-to-1.md`](./06-migration-0x-to-1.md).
 - **Owner**: _TBD_.
-- **Status**: `[ ]`.
+- **Status**: `[x]` — shipped on `feature/m10-strict-log-item`.
 
 ### M11. `bin/assistant-rbs` per-class RBS generator
 

--- a/docs/v1/06-migration-0x-to-1.md
+++ b/docs/v1/06-migration-0x-to-1.md
@@ -47,7 +47,10 @@ Two behavioural changes ship in 1.0 that may require code changes:
 - **Before** (0.1.0): `LogItem.new(level: '', ...)` succeeded and
   `#valid?` returned `false`.
 - **After** (1.0.0): the same call raises `ArgumentError` with a message
-  listing every failing attribute.
+  listing every failing attribute:
+  ```text
+  invalid LogItem: level must be one of [info, warning, error]; source must be present and different from detail
+  ```
 - **Migration**:
   - Audit every direct `LogItem.new` call to confirm the four required
     attrs (`level`, `source`, `detail`, `message`) are non-empty and

--- a/lib/assistant/log_item.rb
+++ b/lib/assistant/log_item.rb
@@ -8,11 +8,12 @@ module Assistant
     attr_reader :level, :source, :detail, :message, :trace
 
     def initialize(level:, source:, detail:, message:, trace: nil)
-      @level = level.to_sym
-      @source = source.to_sym
-      @detail = detail.to_sym
+      @level = normalize_symbol(level)
+      @source = normalize_symbol(source)
+      @detail = normalize_symbol(detail)
       @message = message.to_s
       @trace = trace
+      validate!
     end
 
     def valid?
@@ -35,15 +36,40 @@ module Assistant
     end
 
     def valid_source?
-      source.size.positive? && detail != source
+      present_log_attribute?(source) && detail != source
     end
 
     def valid_detail?
-      detail.size.positive? && source != detail
+      present_log_attribute?(detail) && source != detail
     end
 
     def valid_message?
       message.size.positive?
+    end
+
+    private
+
+    def validate!
+      return if valid?
+
+      raise ArgumentError, "invalid LogItem: #{validation_errors.join('; ')}"
+    end
+
+    def validation_errors
+      errors = []
+      errors << "level must be one of [#{VALID_LEVELS.join(', ')}]" unless valid_level?
+      errors << 'source must be present and different from detail' unless valid_source?
+      errors << 'detail must be present and different from source' unless valid_detail?
+      errors << 'message must be present' unless valid_message?
+      errors
+    end
+
+    def normalize_symbol(value)
+      value.respond_to?(:to_sym) ? value.to_sym : value
+    end
+
+    def present_log_attribute?(value)
+      value.respond_to?(:size) && value.size.positive?
     end
   end
 end

--- a/lib/assistant/log_item.rb
+++ b/lib/assistant/log_item.rb
@@ -4,6 +4,12 @@ module Assistant
   # Log base class
   class LogItem
     VALID_LEVELS = %i[info warning error].freeze
+    ERRORS = [
+      ["level must be one of [#{VALID_LEVELS.join(', ')}]", :valid_level?],
+      ['source must be present and different from detail', :valid_source?],
+      ['detail must be present and different from source', :valid_detail?],
+      ['message must be present', :valid_message?]
+    ].freeze
 
     attr_reader :level, :source, :detail, :message, :trace
 
@@ -16,9 +22,7 @@ module Assistant
       validate!
     end
 
-    def valid?
-      [valid_level?, valid_source?, valid_detail?, valid_message?].all?
-    end
+    def valid? = [valid_level?, valid_source?, valid_detail?, valid_message?].all?
 
     def item
       { level:, source:, detail:, message:, trace: }
@@ -31,38 +35,24 @@ module Assistant
       end
     end
 
-    def valid_level?
-      VALID_LEVELS.include?(level)
-    end
+    def valid_level? = VALID_LEVELS.include?(level)
 
-    def valid_source?
-      present_log_attribute?(source) && detail != source
-    end
+    def valid_source? = present_log_attribute?(source) && detail != source
 
-    def valid_detail?
-      present_log_attribute?(detail) && source != detail
-    end
+    def valid_detail? = present_log_attribute?(detail) && source != detail
 
-    def valid_message?
-      message.size.positive?
-    end
+    def valid_message? = !message.strip.empty?
 
     private
 
     def validate!
-      return if valid?
+      errors = validation_errors
+      return if errors.empty?
 
-      raise ArgumentError, "invalid LogItem: #{validation_errors.join('; ')}"
+      raise ArgumentError, "invalid LogItem: #{errors.join('; ')}"
     end
 
-    def validation_errors
-      errors = []
-      errors << "level must be one of [#{VALID_LEVELS.join(', ')}]" unless valid_level?
-      errors << 'source must be present and different from detail' unless valid_source?
-      errors << 'detail must be present and different from source' unless valid_detail?
-      errors << 'message must be present' unless valid_message?
-      errors
-    end
+    def validation_errors = ERRORS.reject { |_, validation_method| send(validation_method) }.map(&:first)
 
     def normalize_symbol(value)
       value.respond_to?(:to_sym) ? value.to_sym : value

--- a/test/assistant/log_item_test.rb
+++ b/test/assistant/log_item_test.rb
@@ -39,6 +39,14 @@ module Assistant
       assert_match(/message/, error.message)
     end
 
+    def test_log_item_with_whitespace_message_raises
+      error = assert_raises(ArgumentError) do
+        Assistant::LogItem.new(level: :info, source: :source, detail: :detail, message: '   ')
+      end
+
+      assert_match(/message/, error.message)
+    end
+
     def test_log_item_with_same_source_and_detail_raises_with_both_names
       error = assert_raises(ArgumentError) do
         Assistant::LogItem.new(level: :info, source: :same, detail: :same, message: 'message')

--- a/test/assistant/log_item_test.rb
+++ b/test/assistant/log_item_test.rb
@@ -6,14 +6,68 @@ module Assistant
   class LogItemTest < Minitest::Test
     include TestHelpers::LogItems
 
-    def test_invalid_log_item_with_blank_attributes
-      item = Assistant::LogItem.new(level: '', source: '', detail: '', message: '')
+    def test_log_item_with_invalid_level_raises
+      error = assert_raises(ArgumentError) do
+        Assistant::LogItem.new(level: '', source: :source, detail: :detail, message: 'message')
+      end
 
-      refute_predicate item, :valid?
-      refute_predicate item, :valid_level?
-      refute_predicate item, :valid_source?
-      refute_predicate item, :valid_detail?
-      refute_predicate item, :valid_message?
+      assert_match(/invalid LogItem/, error.message)
+      assert_match(/level/, error.message)
+    end
+
+    def test_log_item_with_invalid_source_raises
+      error = assert_raises(ArgumentError) do
+        Assistant::LogItem.new(level: :info, source: '', detail: :detail, message: 'message')
+      end
+
+      assert_match(/source/, error.message)
+    end
+
+    def test_log_item_with_invalid_detail_raises
+      error = assert_raises(ArgumentError) do
+        Assistant::LogItem.new(level: :info, source: :source, detail: '', message: 'message')
+      end
+
+      assert_match(/detail/, error.message)
+    end
+
+    def test_log_item_with_invalid_message_raises
+      error = assert_raises(ArgumentError) do
+        Assistant::LogItem.new(level: :info, source: :source, detail: :detail, message: '')
+      end
+
+      assert_match(/message/, error.message)
+    end
+
+    def test_log_item_with_same_source_and_detail_raises_with_both_names
+      error = assert_raises(ArgumentError) do
+        Assistant::LogItem.new(level: :info, source: :same, detail: :same, message: 'message')
+      end
+
+      assert_match(/source/, error.message)
+      assert_match(/detail/, error.message)
+    end
+
+    def test_log_item_with_multiple_invalid_attributes_aggregates_errors
+      error = assert_raises(ArgumentError) do
+        Assistant::LogItem.new(level: :invalid, source: '', detail: '', message: '')
+      end
+
+      assert_match(/level/, error.message)
+      assert_match(/source/, error.message)
+      assert_match(/detail/, error.message)
+      assert_match(/message/, error.message)
+    end
+
+    def test_log_item_with_nil_attributes_raises_argument_error
+      error = assert_raises(ArgumentError) do
+        Assistant::LogItem.new(level: nil, source: nil, detail: nil, message: nil)
+      end
+
+      assert_match(/level/, error.message)
+      assert_match(/source/, error.message)
+      assert_match(/detail/, error.message)
+      assert_match(/message/, error.message)
     end
 
     def test_info_level_predicates
@@ -53,6 +107,28 @@ module Assistant
     def test_trace_defaults_to_nil_and_round_trips_value
       assert_nil build_log_item.trace
       assert_equal %w[a b], build_log_item(trace: %w[a b]).trace
+    end
+
+    def test_internal_logging_call_sites_construct_valid_log_items
+      service = Class.new(Assistant::Service) do
+        input :token, type: String, required: true, if: ->(value) { value.start_with?('sk-') }
+
+        def validate
+          log_item_info(source: :validate, detail: :started, message: 'started')
+          log_item_warning(source: :validate, detail: :slow, message: 'slow')
+          log_item_error(source: :validate, detail: :failed, message: 'failed')
+        end
+
+        def execute = :ok
+      end
+
+      missing = service.run
+      conditional = service.run(token: 'pk-bad')
+      valid = service.run(token: 'sk-ok')
+
+      assert_equal :with_errors, missing[:status]
+      assert_equal :with_errors, conditional[:status]
+      assert_equal :with_errors, valid[:status]
     end
   end
 end

--- a/test/assistant/log_list_test.rb
+++ b/test/assistant/log_list_test.rb
@@ -14,10 +14,13 @@ module Assistant
       assert_raises(ArgumentError) { @host.add_log }
     end
 
-    def test_add_log_with_invalid_arguments_still_appends
-      result = @host.add_log(level: '', source: '', detail: '', message: '')
+    def test_add_log_with_invalid_arguments_raises_and_does_not_append
+      error = assert_raises(ArgumentError) do
+        @host.add_log(level: '', source: '', detail: '', message: '')
+      end
 
-      assert_equal 1, result.size
+      assert_match(/invalid LogItem/, error.message)
+      assert_empty @host.logs
     end
 
     def test_add_log_with_valid_arguments

--- a/test/assistant/service_test.rb
+++ b/test/assistant/service_test.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
+require_relative '../test_helper'
+
 module Assistant
   class ServiceTest < Minitest::Test
-    # frozen_string_literal: true
-
-    require_relative '../test_helper'
     # ---- Base class without arguments ----
 
     def test_inputs_default_to_empty_hash


### PR DESCRIPTION
## Summary

Make `Assistant::LogItem.new` strict at construction time. Invalid attributes now raise `ArgumentError` instead of producing an invalid object whose `#valid?` returns false.

This implements M10 from [`docs/v1/02-features.md`](../blob/main/docs/v1/02-features.md): `LogItem.new` raises on invalid construction.

## Behaviour

`LogItem` still normalizes symbol-like `level`, `source`, and `detail` values, but initialization now ends with a private `validate!` call. When any structural predicate fails, the raised message aggregates every failing attribute:

```text
invalid LogItem: level must be one of [info, warning, error]; source must be present and different from detail
```

Covered validation failures:

- `level` must be one of `info`, `warning`, `error`.
- `source` must be present and different from `detail`.
- `detail` must be present and different from `source`.
- `message` must be present.

`#valid?`, `#valid_level?`, `#valid_source?`, `#valid_detail?`, and `#valid_message?` are retained for introspection. In normal flows they return `true` after construction; invalid flows now fail before the object escapes.

## Implementation Notes

- Replaced direct `to_sym` calls with `normalize_symbol` so nil/non-symbol-like values raise the intended aggregate `ArgumentError`, not incidental `NoMethodError`.
- Made source/detail predicate checks nil-safe through `present_log_attribute?`.
- Added private `validation_errors` aggregation used by `validate!`.
- `LogList#add_log` inherits the fail-fast behaviour because it constructs `LogItem` internally.

## Tests

`bundle exec rake test` — **128 runs / 383 assertions / 0 failures**.

New or changed coverage:

- Invalid `level` raises and names `level`.
- Invalid `source` raises and names `source`.
- Invalid `detail` raises and names `detail`.
- Invalid `message` raises and names `message`.
- Matching source/detail raises and names both attributes.
- Multiple invalid attributes aggregate in one message.
- Nil attributes raise `ArgumentError` with all relevant names.
- `LogList#add_log` with invalid attrs raises and does not append.
- Audit-style internal call-site test exercises required-input initialize errors, conditional requirement errors, and the M5 info/warning/error shorthands without leaking `ArgumentError`.
- Fixed `test/assistant/service_test.rb` header so it can run standalone.

Standalone verification also ran:

```sh
bundle exec ruby -Itest test/assistant/service_test.rb
```

Result: **16 runs / 40 assertions / 0 failures**.

## Tooling

`bundle exec rubocop` — **30 files inspected, no offenses detected**.

## Docs

- M10 marked complete in `docs/v1/02-features.md`.
- `docs/v1/06-migration-0x-to-1.md` tightened with the aggregate error shape.
- `CHANGELOG.md` `[Unreleased]` documents the breaking strict-construction behaviour.

## Migration

Audit direct `Assistant::LogItem.new(...)` and `add_log(level:, source:, detail:, message:)` call sites. Any fixtures that expected `LogItem.new(...)` to succeed while `#valid? == false` need to switch to asserting `ArgumentError`.

The gem's internal logging paths are covered by the new audit test.