### PR TITLE
chore: add opencode project config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 .rspec_status
 .byebug_history
 assistant-*.gem
+.vscode/

--- a/.opencode/.gitignore
+++ b/.opencode/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+package.json
+package-lock.json
+bun.lock

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": [
+    "@tarquinen/opencode-dcp@latest"
+  ]
+}


### PR DESCRIPTION
## Summary
- add project-level opencode config for the DCP plugin
- ignore generated opencode install artifacts under .opencode
- ignore local VS Code settings

## Validation
- ruby -rjson -e 'JSON.parse(File.read(".opencode/opencode.json")); puts "opencode config JSON OK"'
- git diff --cached --check