### PR TITLE
docs(v1): mark M4 and M6 as shipped

### DIFF
--- a/docs/v1/02-features.md
+++ b/docs/v1/02-features.md
@@ -239,7 +239,7 @@ documented to avoid surprise.
   `infos + warnings + errors` modulo ordering.
 - **Risk**: trivial. Add `attr_reader :logs` to `Assistant::Service`.
 - **Owner**: _TBD_.
-- **Status**: `[ ]`.
+- **Status**: `[x]` — shipped in PR #133 (`d6ba7d1`).
 
 ### M5. Generic `log_item_*` shorthands on `LogList`
 
@@ -282,7 +282,7 @@ documented to avoid surprise.
   `defined?(Assistant::LogList)`.
 - **Risk**: trivial.
 - **Owner**: _TBD_.
-- **Status**: `[ ]`.
+- **Status**: `[x]` — shipped in PR #132 (`231a519`).
 
 ### M7. `input(..., optional:)`
 


### PR DESCRIPTION
Both items landed earlier but their status checkboxes in `docs/v1/02-features.md` were never flipped.

- **M4** (`Service#logs` reader) shipped in PR #133 (`d6ba7d1`).
- **M6** (lazy load of `LogItem`) shipped in PR #132 (`231a519`).

Code, tests, RBS, and CHANGELOG entries for both are already in `main`; this PR is docs-only so the roadmap reflects the actual shipped state.