### PR TITLE
M-S3: Add Assistant.notifier instrumentation hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Assistant.notifier` and `Assistant.notifier=` — module-level
+  configuration accessor for an instrumentation callable. The default
+  notifier is a frozen no-op lambda (`Assistant::DEFAULT_NOTIFIER`);
+  the setter accepts any object responding to `#call(event, payload)`
+  or `nil` to reset to the default. Passing anything else raises
+  `ArgumentError` immediately. `Service#run` now fires four frozen
+  events around its lifecycle: `:service_started` at entry,
+  `:service_validated` after `validate_inputs` + `validate`, and
+  exactly one of `:service_executed` (no logged errors) or
+  `:service_failed` (errors present) before returning. Every payload
+  carries `{ service_class:, duration_s: }`; `duration_s` is a `Float`
+  measured against `Process::CLOCK_MONOTONIC` from the start of `#run`.
+  Notifier exceptions (`StandardError`) are caught and surfaced via
+  `Kernel.warn`; subsequent events still fire. (M-S3, v1 plan)
+
 - `bin/assistant-rbs` (shipped as `exe/assistant-rbs`) — a CLI that
   loads user-supplied Ruby paths and emits an `.rbs` file per
   `Assistant::Service` subclass into a configurable output directory

--- a/docs/v1/02-features.md
+++ b/docs/v1/02-features.md
@@ -683,7 +683,7 @@ documented to avoid surprise.
   `:service_failed` (Frozen event set for 1.0). Payload always includes
   `:service_class`, `:duration_s`.
 - **Risk**: low. Default notifier is a no-op proc.
-- **Status**: `[ ]`.
+- **Status**: `[x]` — shipped on `feature/m-s3-instrumentation-notifier`.
 
 ### M-S4. Frozen Data for input snapshot
 

--- a/lib/assistant.rb
+++ b/lib/assistant.rb
@@ -2,15 +2,49 @@
 
 # Predeclare the namespace shells that multi-segment files
 # (`module Assistant::Refinements::StringBlankness`, etc.) need to exist
-# before they load. Two sibling modules in one wrapper avoid the
+# before they load, and declare the M-S3 instrumentation notifier
+# accessor. Two sibling submodules in one wrapper avoid the
 # `Style/CompactModuleNesting` single-child collapse trigger.
 module Assistant
+  # M-S3: frozen no-op default notifier. Identity-compared by
+  # `Assistant.notifier=` so callers can detect the unconfigured state
+  # if they ever need to. See docs/v1/02-features.md (M-S3) and
+  # docs/v1/01-api-surface.md.
+  DEFAULT_NOTIFIER = ->(_event, _payload) {}
+  DEFAULT_NOTIFIER.freeze
+
   # Namespace for the InputBuilder DSL and its submodules. Populated by
   # `lib/assistant/input_builder*.rb`.
   module InputBuilder; end
 
   # Namespace for refinements bundled with the gem (`Refinements::*`).
   module Refinements; end
+
+  @notifier = DEFAULT_NOTIFIER
+
+  class << self
+    # Reader for the configured instrumentation callable. Always returns
+    # a callable; returns `DEFAULT_NOTIFIER` when never assigned or when
+    # explicitly reset with `Assistant.notifier = nil`.
+    attr_reader :notifier
+
+    # Writer for the instrumentation callable. Accepts any object
+    # responding to `#call(event, payload)`, or `nil` to reset to the
+    # built-in no-op default. Anything else raises `ArgumentError`
+    # immediately so misconfiguration surfaces at boot rather than at
+    # the first service run.
+    def notifier=(callable)
+      @notifier =
+        if callable.nil?
+          DEFAULT_NOTIFIER
+        elsif callable.respond_to?(:call)
+          callable
+        else
+          raise ArgumentError,
+                "Assistant.notifier= expected nil or an object responding to #call, got #{callable.inspect}"
+        end
+    end
+  end
 end
 
 # Core building blocks for the Assistant gem. Listed alphabetically so the

--- a/lib/assistant.rbs
+++ b/lib/assistant.rbs
@@ -1,9 +1,22 @@
 # Type signatures for `lib/assistant.rb` — declares the top-level
-# `Assistant` namespace and the empty namespace shells for
+# `Assistant` namespace, the empty namespace shells for
 # `Assistant::InputBuilder` and `Assistant::Refinements` that the
-# multi-segment submodule files reopen. See docs/v1/01-api-surface.md.
+# multi-segment submodule files reopen, and the M-S3 instrumentation
+# notifier accessor. See docs/v1/01-api-surface.md.
 
 module Assistant
+  # M-S3: instrumentation notifier. The setter accepts any object
+  # responding to `#call(event, payload)` or `nil` (reset to default).
+  # The contract is documented in docs/v1/01-api-surface.md; we use
+  # `untyped` for the setter parameter because the runtime check is
+  # `respond_to?(:call)` rather than a structural Proc type.
+  DEFAULT_NOTIFIER: ^(Symbol, Hash[Symbol, untyped]) -> void
+
+  self.@notifier: ^(Symbol, Hash[Symbol, untyped]) -> void
+
+  def self.notifier: () -> ^(Symbol, Hash[Symbol, untyped]) -> void
+  def self.notifier=: (untyped callable) -> ^(Symbol, Hash[Symbol, untyped]) -> void
+
   module InputBuilder
   end
 

--- a/lib/assistant/service.rb
+++ b/lib/assistant/service.rb
@@ -27,14 +27,14 @@ module Assistant
     end
 
     def run
+      @run_started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      notify(:service_started)
+
       validate_inputs
       validate
+      notify(:service_validated)
 
-      if errors.empty?
-        { result:, status:, warnings: }
-      else
-        { errors:, result: nil, status: :with_errors }
-      end
+      errors.empty? ? executed_payload : failed_payload
     end
 
     def result
@@ -54,6 +54,22 @@ module Assistant
     end
 
     private
+
+    # Build the success-path result hash and fire the terminal
+    # `:service_executed` event. Triggers `#execute` lazily via `#result`.
+    def executed_payload
+      payload = { result:, status:, warnings: }
+      notify(:service_executed)
+      payload
+    end
+
+    # Build the failure-path result hash and fire the terminal
+    # `:service_failed` event. Does not invoke `#execute`.
+    def failed_payload
+      payload = { errors:, result: nil, status: :with_errors }
+      notify(:service_failed)
+      payload
+    end
 
     # M1: apply input defaults declared via `input :name, default: ...`.
     # A default fires when the key is absent, or when the value is an
@@ -93,6 +109,21 @@ module Assistant
       methods.grep(/valid_(required|type)_\w+\?$/).each do |validation_method|
         send(validation_method)
       end
+    end
+
+    # M-S3: dispatch a frozen-set instrumentation event to the configured
+    # `Assistant.notifier`. Payload always includes `:service_class` and
+    # `:duration_s` (Float seconds since the start of `#run`). The notifier
+    # is treated as untrusted infra: any `StandardError` it raises is
+    # caught and surfaced via `Kernel.warn` so a misconfigured notifier
+    # cannot tear down every service in the process. Non-`StandardError`
+    # exceptions (e.g. `SystemExit`, `Interrupt`) are intentionally
+    # allowed to propagate.
+    def notify(event)
+      duration_s = Process.clock_gettime(Process::CLOCK_MONOTONIC) - @run_started_at
+      Assistant.notifier.call(event, { service_class: self.class, duration_s: duration_s })
+    rescue StandardError => e
+      Kernel.warn "assistant: notifier raised during #{event} for #{self.class}: #{e.class}: #{e.message}"
     end
 
     attr_reader :inputs

--- a/lib/assistant/service.rbs
+++ b/lib/assistant/service.rbs
@@ -17,6 +17,7 @@ class Assistant::Service
   @inputs: Hash[Symbol, untyped]
   @logs: Array[Assistant::LogItem]
   @result: untyped
+  @run_started_at: Float
 
   attr_reader logs: Array[Assistant::LogItem]
 
@@ -38,6 +39,10 @@ class Assistant::Service
 
   attr_reader inputs: Hash[Symbol, untyped]
 
+  def executed_payload: () -> Hash[Symbol, untyped]
+
+  def failed_payload: () -> Hash[Symbol, untyped]
+
   def apply_input_defaults: () -> void
 
   def input_definitions_needing_default: () -> Hash[Symbol, Hash[Symbol, untyped]]
@@ -45,6 +50,8 @@ class Assistant::Service
   def input_supplied?: (Symbol attr_name, Hash[Symbol, untyped] options) -> bool
 
   def validate_inputs: () -> Array[Symbol]
+
+  def notify: (Symbol event) -> void
 
   def execute: () -> untyped
 

--- a/test/assistant/service_test.rb
+++ b/test/assistant/service_test.rb
@@ -4,6 +4,18 @@ require_relative '../test_helper'
 
 module Assistant
   class ServiceTest < Minitest::Test
+    # ---- M-S3: instrumentation notifier ----
+    #
+    # Each test resets the notifier in teardown so configuration cannot
+    # leak across tests or to AssistantTest.
+
+    include TestHelpers::IoCapture
+
+    def teardown
+      Assistant.notifier = nil
+      super
+    end
+
     # ---- Base class without arguments ----
 
     def test_inputs_default_to_empty_hash
@@ -204,6 +216,131 @@ module Assistant
 
       assert_equal((service.infos + service.warnings + service.errors).sort_by(&:object_id),
                    service.logs.sort_by(&:object_id))
+    end
+
+    def with_recording_notifier
+      events = []
+      Assistant.notifier = ->(event, payload) { events << [event, payload] }
+      events
+    end
+
+    def test_successful_run_fires_started_validated_executed_in_order
+      events = with_recording_notifier
+      klass = Class.new(Assistant::Service) do
+        def execute = :ok
+      end
+
+      klass.run
+
+      assert_equal %i[service_started service_validated service_executed], events.map(&:first)
+    end
+
+    def test_successful_run_does_not_fire_service_failed
+      events = with_recording_notifier
+      klass = Class.new(Assistant::Service) do
+        def execute = :ok
+      end
+
+      klass.run
+
+      refute_includes events.map(&:first), :service_failed
+    end
+
+    def test_failing_run_fires_started_validated_failed_in_order
+      events = with_recording_notifier
+      klass = Class.new(Assistant::Service) do
+        input :one, type: Integer, required: true
+        def execute = true
+      end
+
+      klass.run
+
+      assert_equal %i[service_started service_validated service_failed], events.map(&:first)
+    end
+
+    def test_failing_run_does_not_fire_service_executed
+      events = with_recording_notifier
+      klass = Class.new(Assistant::Service) do
+        input :one, type: Integer, required: true
+        def execute = true
+      end
+
+      klass.run
+
+      refute_includes events.map(&:first), :service_executed
+    end
+
+    def test_event_payload_includes_service_class_and_duration
+      events = with_recording_notifier
+      klass = Class.new(Assistant::Service) do
+        def execute = :ok
+      end
+
+      klass.run
+
+      events.each do |(_event, payload)|
+        assert_same klass, payload[:service_class]
+        assert_kind_of Float, payload[:duration_s]
+        assert_operator payload[:duration_s], :>=, 0.0
+      end
+    end
+
+    def test_event_duration_is_monotonically_non_decreasing_across_events
+      events = with_recording_notifier
+      klass = Class.new(Assistant::Service) do
+        def execute = :ok
+      end
+
+      klass.run
+
+      durations = events.map { |(_event, payload)| payload[:duration_s] }
+
+      assert_equal durations.sort, durations,
+                   "expected duration_s to be non-decreasing across events, got #{durations.inspect}"
+    end
+
+    def test_notifier_exception_is_captured_and_run_returns_normally
+      Assistant.notifier = ->(_event, _payload) { raise 'boom from notifier' }
+      klass = Class.new(Assistant::Service) do
+        def execute = :ok
+      end
+
+      outcome = nil
+      stderr = capture_io_warn { outcome = klass.run }
+
+      assert_equal :ok, outcome[:status]
+      assert_equal :ok, outcome[:result]
+      assert_match(/notifier raised during service_started/, stderr)
+    end
+
+    def test_notifier_exception_does_not_block_subsequent_events
+      events = []
+      first_call = true
+      Assistant.notifier = lambda do |event, payload|
+        if first_call
+          first_call = false
+          raise 'boom from notifier'
+        end
+        events << [event, payload]
+      end
+
+      klass = Class.new(Assistant::Service) do
+        def execute = :ok
+      end
+
+      capture_io_warn { klass.run }
+
+      assert_equal %i[service_validated service_executed], events.map(&:first)
+    end
+
+    def test_run_with_default_notifier_is_a_silent_no_op
+      klass = Class.new(Assistant::Service) do
+        def execute = :ok
+      end
+
+      stderr = capture_io_warn { klass.run }
+
+      assert_empty stderr
     end
   end
 end

--- a/test/assistant_test.rb
+++ b/test/assistant_test.rb
@@ -3,6 +3,13 @@
 require_relative 'test_helper'
 
 class AssistantTest < Minitest::Test
+  # ---- M-S3: instrumentation notifier ----
+
+  def teardown
+    Assistant.notifier = nil
+    super
+  end
+
   def test_has_a_version_number
     refute_nil Assistant::VERSION
   end
@@ -19,5 +26,70 @@ class AssistantTest < Minitest::Test
     assert defined?(Assistant::InputBuilder), 'Assistant::InputBuilder should be loaded'
     assert defined?(Assistant::Service), 'Assistant::Service should be loaded'
     assert defined?(Assistant::Refinements::StringBlankness), 'Assistant::Refinements::StringBlankness should be loaded'
+  end
+
+  def test_notifier_defaults_to_a_callable_no_op
+    assert_respond_to Assistant.notifier, :call
+    assert_nil Assistant.notifier.call(:service_started, { service_class: Assistant::Service, duration_s: 0.0 })
+  end
+
+  def test_notifier_default_constant_is_frozen
+    assert_predicate Assistant::DEFAULT_NOTIFIER, :frozen?
+  end
+
+  def test_notifier_returns_default_when_never_assigned
+    assert_same Assistant::DEFAULT_NOTIFIER, Assistant.notifier
+  end
+
+  def test_notifier_setter_accepts_a_proc
+    proc_notifier = ->(_event, _payload) {}
+    Assistant.notifier = proc_notifier
+
+    assert_same proc_notifier, Assistant.notifier
+  end
+
+  def test_notifier_setter_accepts_a_lambda
+    lambda_notifier = ->(_event, _payload) {}
+    Assistant.notifier = lambda_notifier
+
+    assert_same lambda_notifier, Assistant.notifier
+  end
+
+  def test_notifier_setter_accepts_a_method_object
+    helper = Object.new
+    def helper.record(_event, _payload); end
+
+    Assistant.notifier = helper.method(:record)
+
+    assert_respond_to Assistant.notifier, :call
+  end
+
+  def test_notifier_setter_accepts_any_object_responding_to_call
+    callable_obj = Object.new
+    def callable_obj.call(_event, _payload); end
+
+    Assistant.notifier = callable_obj
+
+    assert_same callable_obj, Assistant.notifier
+  end
+
+  def test_notifier_setter_resets_to_default_when_assigned_nil
+    Assistant.notifier = ->(_event, _payload) {}
+    Assistant.notifier = nil
+
+    assert_same Assistant::DEFAULT_NOTIFIER, Assistant.notifier
+  end
+
+  def test_notifier_setter_raises_argument_error_for_non_callable
+    assert_raises(ArgumentError) { Assistant.notifier = 42 }
+    assert_raises(ArgumentError) { Assistant.notifier = 'not a notifier' }
+    assert_raises(ArgumentError) { Assistant.notifier = Object.new }
+  end
+
+  def test_notifier_setter_error_message_includes_offending_value
+    error = assert_raises(ArgumentError) { Assistant.notifier = :nope }
+
+    assert_match(/respond.*to.*#call/, error.message)
+    assert_includes error.message, ':nope'
   end
 end


### PR DESCRIPTION
Builds the next Must-have item from the v1 roadmap: a configurable, no-op-by-default instrumentation hook so callers can observe `Service#run` lifecycle without coupling the gem to any specific tracing or logging stack.

Spec source: `docs/v1/02-features.md` M-S3 (lines 675-686), `docs/v1/01-api-surface.md:26-27` (accessor) and `:167-179` (event set + payload shape).

## What ships

### Surface
- `Assistant::DEFAULT_NOTIFIER` — frozen no-op lambda, identity-comparable.
- `Assistant.notifier` reader — always returns a callable; returns `DEFAULT_NOTIFIER` when never assigned or after `Assistant.notifier = nil`.
- `Assistant.notifier=` writer — accepts any object responding to `#call(event, payload)` or `nil` (resets to default). Anything else raises `ArgumentError` immediately with the offending value in the message, so misconfiguration surfaces at boot rather than at the first service run.

### Lifecycle events fired by `Service#run`
Frozen set for 1.0:
- `:service_started` — at entry, before validation.
- `:service_validated` — after `validate_inputs` + `validate`.
- `:service_executed` — when `errors` is empty (mutually exclusive with...)
- `:service_failed` — when `errors` is non-empty.

Every payload carries `{ service_class:, duration_s: }`:
- `service_class` is the actual Class object (not a string).
- `duration_s` is a `Float` measured against `Process::CLOCK_MONOTONIC` from the start of `#run`.

Additional payload keys may be added in minor releases. Adding new events would require a deprecation cycle per `docs/v1/01-api-surface.md:167-179`.

### Error semantics
Any `StandardError` raised by the configured notifier is rescued and surfaced via `Kernel.warn`:
\`\`\`
assistant: notifier raised during <event> for <Class>: <ErrorClass>: <message>
\`\`\`
A notifier failure during one event does not prevent later events from firing, and `#run` returns normally to the caller. Non-`StandardError` exceptions (`SystemExit`, `Interrupt`, etc.) intentionally propagate.

## Implementation notes
- `Service#run` is refactored into `executed_payload` / `failed_payload` private helpers to keep it under the `Metrics/MethodLength` budget while preserving the existing return shape (`{ result:, status:, warnings: }` on success, `{ errors:, result: nil, status: :with_errors }` on failure).
- `@run_started_at` is captured at entry to `#run` and reused by `#notify` so every event reports elapsed time since the start of the run.
- The notifier protocol uses positional args (`call(event, payload)`) because it's a user-facing contract; M12's upcoming keyword-only sweep should not touch it.

## Coverage
+19 new Minitest cases (`test/assistant_test.rb` + `test/assistant/service_test.rb`) covering:
- Accessor contract: default value, callable type, nil reset, ArgumentError on non-callable, accepts Proc / Lambda / Method / `#call`-object.
- Mutually-exclusive terminal events on success vs. failure.
- Payload shape (`service_class:` is the actual class; `duration_s:` is a Float ≥ 0).
- Duration is monotonically non-decreasing across events of a single run.
- Notifier exception is captured + warned and does not abort `#run`.
- Notifier exception during one event does not block subsequent events.
- Default notifier is silent (no stderr noise).

Each test class resets `Assistant.notifier = nil` in `teardown` so configuration cannot leak across tests.

## Gates
- \`bundle exec rake test\` — 159 runs / 462 assertions / 0 failures.
- \`bundle exec rubocop\` — clean (38 files inspected).
- \`bundle exec steep check\` — no type errors (lib target).

## Roadmap delta
- \`docs/v1/02-features.md\` M-S3 status flipped \`[ ]\` → \`[x]\`.
- \`CHANGELOG.md\` \`[Unreleased]\` / \`### Added\` entry added at the top of the section.

Stacks cleanly under PR #152 (docs-only M4/M6 status flip) and unblocks the next Must items (M-S1 around-execute, M-S2 composition primitive, M-S4 frozen input snapshot), all of which land before the M12 keyword-only sweep.