### PR TITLE
M-S1: Add before/after/around execute callbacks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -80,6 +80,13 @@ Metrics/MethodLength:
   Exclude:
     - 'test/**/*.rb'
 
+# Test files use anonymous Class.new blocks with multiple assertions
+# that inflate ABC counts beyond the cop's heuristic without reflecting
+# real branching complexity.
+Metrics/AbcSize:
+  Exclude:
+    - 'test/**/*.rb'
+
 Naming/MethodParameterName:
   AllowedNames:
     - a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `before_execute`, `after_execute { |result| }`, and
+  `around_execute { |&blk| ... }` class-level DSL on
+  `Assistant::Service` for wrapping `#execute` with reusable hooks.
+  Hooks are `instance_exec`'d on the service (so `self` is the service
+  instance) and execute after validation in declaration order; the
+  first-declared `around_execute` is the outermost layer. Hooks are
+  inherited at subclass-definition time via an array snapshot — later
+  additions on the parent do not bleed into existing subclasses. Errors
+  raised inside any hook are caught, never propagate out of `#run`,
+  and are logged via `add_log(level: :error, source: :hook, detail:
+  <hook_type>, message: "<ErrorClass>: <message>", trace: backtrace)`.
+  A hook-logged error downgrades the terminal lifecycle event to
+  `:service_failed` and the run payload to `{ errors:, result: nil,
+  status: :with_errors }`; the actual execute return value remains
+  accessible via `service.result`. (M-S1, v1 plan)
+
 - `Assistant.notifier` and `Assistant.notifier=` — module-level
   configuration accessor for an instrumentation callable. The default
   notifier is a frozen no-op lambda (`Assistant::DEFAULT_NOTIFIER`);

--- a/docs/v1/02-features.md
+++ b/docs/v1/02-features.md
@@ -646,7 +646,7 @@ documented to avoid surprise.
   logged via `add_log(level: :error, source: :hook, …)`; they never
   propagate out of `#run`. Around-hook composition uses the inner-most
   block last (declaration order wraps).
-- **Status**: `[ ]`.
+- **Status**: `[x]` — shipped on `feature/m-s1-execute-callbacks`.
 
 ### M-S2. Service composition primitive
 

--- a/lib/assistant.rb
+++ b/lib/assistant.rb
@@ -50,6 +50,7 @@ end
 # Core building blocks for the Assistant gem. Listed alphabetically so the
 # top-level entry point exposes every public constant after a bare
 # `require "assistant"` (M6).
+require 'assistant/execute_callbacks'
 require 'assistant/input_builder'
 require 'assistant/log_item'
 require 'assistant/log_list'

--- a/lib/assistant/execute_callbacks.rb
+++ b/lib/assistant/execute_callbacks.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+# Class-level DSL for registering `before_execute` / `after_execute` /
+# `around_execute` hooks on `Assistant::Service` subclasses (M-S1).
+#
+# Mixed into `Service.singleton_class` so the DSL is available at class
+# definition time. Hooks are stored as `UnboundMethod`s on private
+# anonymous Modules so we can bind `self` to the service instance and
+# still pass a block (the continuation) into `around_execute` hooks.
+#
+# Hooks are inherited at subclass-definition time: a subclass receives
+# a duplicate of each registered hook array. Adding more hooks to the
+# subclass does not affect the parent, and vice-versa.
+#
+# See docs/v1/02-features.md M-S1 and docs/v1/01-api-surface.md.
+module Assistant::ExecuteCallbacks
+  HOOK_TYPES = %i[before_execute after_execute around_execute].freeze
+
+  def before_execute_hooks
+    @before_execute_hooks ||= []
+  end
+
+  def after_execute_hooks
+    @after_execute_hooks ||= []
+  end
+
+  def around_execute_hooks
+    @around_execute_hooks ||= []
+  end
+
+  # Register a block to run after validation and before `#execute`.
+  # `self` inside the block is the service instance.
+  def before_execute(&block)
+    raise ArgumentError, 'before_execute requires a block' unless block
+
+    before_execute_hooks << build_hook(block)
+  end
+
+  # Register a block to run after `#execute` returns. `self` inside the
+  # block is the service instance; the execute result is passed as the
+  # single positional argument.
+  def after_execute(&block)
+    raise ArgumentError, 'after_execute requires a block' unless block
+
+    after_execute_hooks << build_hook(block)
+  end
+
+  # Register a block that wraps `#execute`. `self` inside the block is
+  # the service instance; the `&blk` block argument yields to the
+  # inner stack (the next around hook, or `#execute` for the innermost
+  # layer). Declaration order wraps: the first declared hook is the
+  # outermost layer.
+  def around_execute(&block)
+    raise ArgumentError, 'around_execute requires a block' unless block
+
+    around_execute_hooks << build_hook(block)
+  end
+
+  # Snapshot parent hooks into the subclass at definition time. The
+  # snapshot is a `dup` so the subclass owns its own array and further
+  # additions on either side never bleed across the hierarchy.
+  def inherited(subclass)
+    super
+    subclass.instance_variable_set(:@before_execute_hooks, before_execute_hooks.dup)
+    subclass.instance_variable_set(:@after_execute_hooks,  after_execute_hooks.dup)
+    subclass.instance_variable_set(:@around_execute_hooks, around_execute_hooks.dup)
+  end
+
+  private
+
+  # Wrap the user's block in an anonymous Module so we can convert it
+  # to an `UnboundMethod`. `um.bind_call(service, *args, &cont)` then
+  # runs the user's block with `self` == the service instance AND
+  # passes a block argument through to the block's `&blk` parameter,
+  # which is essential for `around_execute` continuations and cannot
+  # be expressed with `instance_exec` alone.
+  def build_hook(block)
+    mod = Module.new
+    mod.send(:define_method, :__assistant_execute_hook__, &block)
+    mod.instance_method(:__assistant_execute_hook__)
+  end
+end

--- a/lib/assistant/execute_callbacks.rbs
+++ b/lib/assistant/execute_callbacks.rbs
@@ -1,0 +1,30 @@
+# Type signatures for `lib/assistant/execute_callbacks.rb`. See
+# docs/v1/01-api-surface.md for the frozen 1.0 surface. The block types
+# for `before_execute` / `after_execute` / `around_execute` are loosely
+# typed because the user's block can take a `&blk` continuation, varied
+# `result` shapes, or no arguments at all — RBS cannot model the
+# `instance_exec`-like rebinding precisely.
+
+module Assistant
+  module ExecuteCallbacks
+    HOOK_TYPES: Array[Symbol]
+
+    @before_execute_hooks: Array[UnboundMethod]
+    @after_execute_hooks: Array[UnboundMethod]
+    @around_execute_hooks: Array[UnboundMethod]
+
+    def before_execute_hooks: () -> Array[UnboundMethod]
+    def after_execute_hooks: () -> Array[UnboundMethod]
+    def around_execute_hooks: () -> Array[UnboundMethod]
+
+    def before_execute: () { (*untyped) -> untyped } -> Array[UnboundMethod]
+    def after_execute: () { (*untyped) -> untyped } -> Array[UnboundMethod]
+    def around_execute: () { (*untyped) -> untyped } -> Array[UnboundMethod]
+
+    def inherited: (Class subclass) -> void
+
+    private
+
+    def build_hook: (Proc block) -> UnboundMethod
+  end
+end

--- a/lib/assistant/service.rb
+++ b/lib/assistant/service.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
+require_relative 'execute_callbacks'
 require_relative 'input_builder'
 require_relative 'log_list'
 
 module Assistant
-  # Base class for the Assistant gem
-  class Service
+  # Core Service base class. Subclasses declare inputs via the
+  # InputBuilder DSL, optionally register before/after/around execute
+  # hooks via ExecuteCallbacks, and implement `#execute`.
+  class Service # rubocop:disable Metrics/ClassLength
     include Assistant::LogList
 
     # Public reader for the full log timeline (info + warning + error), in
@@ -14,6 +17,7 @@ module Assistant
 
     class << self
       include Assistant::InputBuilder
+      include Assistant::ExecuteCallbacks
 
       def run(**)
         new(**).run
@@ -34,11 +38,17 @@ module Assistant
       validate
       notify(:service_validated)
 
+      return failed_payload if errors.any?
+
+      # Trigger `#execute` (through the M-S1 hook chain) eagerly so any
+      # error logged by a `before_/after_/around_execute` hook influences
+      # the terminal event and the payload's `:status` field.
+      result
       errors.empty? ? executed_payload : failed_payload
     end
 
     def result
-      @result ||= execute
+      @result ||= run_execute_with_callbacks
     end
 
     def success?
@@ -124,6 +134,79 @@ module Assistant
       Assistant.notifier.call(event, { service_class: self.class, duration_s: duration_s })
     rescue StandardError => e
       Kernel.warn "assistant: notifier raised during #{event} for #{self.class}: #{e.class}: #{e.message}"
+    end
+
+    # M-S1: thread `#execute` through the registered before/around/after
+    # hook chains. Called once via `#result`'s memoization, so each
+    # service instance runs hooks at most once even if `#result` is
+    # invoked repeatedly.
+    def run_execute_with_callbacks
+      run_before_execute_hooks
+      result = run_around_execute_chain
+      run_after_execute_hooks(result)
+      result
+    end
+
+    # M-S1: invoke every registered `before_execute` hook in declaration
+    # order. Each hook is independent — a `StandardError` from one is
+    # logged via `add_log(level: :error, source: :hook, …)` and the
+    # remaining hooks still fire.
+    def run_before_execute_hooks
+      self.class.before_execute_hooks.each do |hook|
+        hook.bind_call(self)
+      rescue StandardError => e
+        log_hook_error(:before_execute, e)
+      end
+    end
+
+    # M-S1: invoke every registered `after_execute` hook in declaration
+    # order, passing the execute result as the single positional arg.
+    def run_after_execute_hooks(execute_result)
+      self.class.after_execute_hooks.each do |hook|
+        hook.bind_call(self, execute_result)
+      rescue StandardError => e
+        log_hook_error(:after_execute, e)
+      end
+    end
+
+    # M-S1: build the around-hook chain from the innermost layer (the
+    # raw `#execute` call) outwards. Declaration order wraps: the
+    # first-declared hook is the outermost layer. If an around hook
+    # raises before yielding to its continuation, that layer (and any
+    # inner layers, including `#execute` itself) does not run; the
+    # layer returns `nil` and outer hooks still wrap normally.
+    def run_around_execute_chain
+      chain = -> { execute }
+      self.class.around_execute_hooks.reverse_each do |hook|
+        chain = wrap_around_layer(hook, chain)
+      end
+      chain.call
+    end
+
+    # Build a single around layer: a lambda that runs `hook` with
+    # `inner` as its continuation. Hook exceptions raised before the
+    # continuation runs are caught, logged, and the layer returns nil.
+    def wrap_around_layer(hook, inner)
+      lambda do
+        hook.bind_call(self, &inner)
+      rescue StandardError => e
+        log_hook_error(:around_execute, e)
+        nil
+      end
+    end
+
+    # M-S1: shared hook-error logger. Stamps `source: :hook` and uses
+    # the hook type as `detail:` so callers can grep their log timeline
+    # by either field. The exception's backtrace is preserved on the
+    # `LogItem#trace` field for downstream diagnostics.
+    def log_hook_error(hook_type, exception)
+      add_log(
+        level: :error,
+        source: :hook,
+        detail: hook_type,
+        message: "#{exception.class}: #{exception.message}",
+        trace: exception.backtrace
+      )
     end
 
     attr_reader :inputs

--- a/lib/assistant/service.rbs
+++ b/lib/assistant/service.rbs
@@ -13,6 +13,7 @@ class Assistant::Service
   include Assistant::LogList
 
   extend Assistant::InputBuilder
+  extend Assistant::ExecuteCallbacks
 
   @inputs: Hash[Symbol, untyped]
   @logs: Array[Assistant::LogItem]
@@ -52,6 +53,18 @@ class Assistant::Service
   def validate_inputs: () -> Array[Symbol]
 
   def notify: (Symbol event) -> void
+
+  def run_execute_with_callbacks: () -> untyped
+
+  def run_before_execute_hooks: () -> Array[UnboundMethod]
+
+  def run_after_execute_hooks: (untyped execute_result) -> Array[UnboundMethod]
+
+  def run_around_execute_chain: () -> untyped
+
+  def wrap_around_layer: (UnboundMethod hook, ^() -> untyped inner) -> ^() -> untyped
+
+  def log_hook_error: (Symbol hook_type, Exception exception) -> void
 
   def execute: () -> untyped
 

--- a/test/assistant/execute_callbacks_test.rb
+++ b/test/assistant/execute_callbacks_test.rb
@@ -1,0 +1,495 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+module Assistant
+  class ExecuteCallbacksTest < Minitest::Test
+    # ---- DSL surface ----
+
+    def test_service_class_responds_to_execute_callback_dsl
+      assert_respond_to Assistant::Service, :before_execute
+      assert_respond_to Assistant::Service, :after_execute
+      assert_respond_to Assistant::Service, :around_execute
+    end
+
+    def test_before_execute_requires_a_block
+      klass = Class.new(Assistant::Service)
+      assert_raises(ArgumentError) { klass.before_execute }
+    end
+
+    def test_after_execute_requires_a_block
+      klass = Class.new(Assistant::Service)
+      assert_raises(ArgumentError) { klass.after_execute }
+    end
+
+    def test_around_execute_requires_a_block
+      klass = Class.new(Assistant::Service)
+      assert_raises(ArgumentError) { klass.around_execute }
+    end
+
+    def test_base_service_class_has_no_registered_hooks
+      assert_empty Assistant::Service.before_execute_hooks
+      assert_empty Assistant::Service.after_execute_hooks
+      assert_empty Assistant::Service.around_execute_hooks
+    end
+
+    def test_fresh_subclass_starts_with_empty_hook_arrays
+      klass = Class.new(Assistant::Service)
+
+      assert_empty klass.before_execute_hooks
+      assert_empty klass.after_execute_hooks
+      assert_empty klass.around_execute_hooks
+    end
+
+    # ---- before_execute ----
+
+    def test_before_execute_runs_before_execute_with_service_as_self
+      seen = []
+      klass = Class.new(Assistant::Service) do
+        before_execute { seen << [:before, self] }
+        define_method(:execute) do
+          seen << [:execute, self]
+          :ok
+        end
+      end
+
+      instance = klass.new
+      instance.run
+
+      assert_equal :before,  seen[0][0]
+      assert_equal :execute, seen[1][0]
+      assert_same instance, seen[0][1]
+      assert_same instance, seen[1][1]
+    end
+
+    def test_before_execute_runs_after_validation
+      seen = []
+      klass = Class.new(Assistant::Service) do
+        define_method(:validate) { seen << :validate }
+        before_execute { seen << :before }
+        define_method(:execute) { seen << :execute }
+      end
+
+      klass.run
+
+      assert_equal %i[validate before execute], seen
+    end
+
+    def test_multiple_before_execute_hooks_run_in_declaration_order
+      seen = []
+      klass = Class.new(Assistant::Service) do
+        before_execute { seen << :first }
+        before_execute { seen << :second }
+        before_execute { seen << :third }
+        def execute = :ok
+      end
+
+      klass.run
+
+      assert_equal %i[first second third], seen
+    end
+
+    def test_before_execute_can_add_logs
+      klass = Class.new(Assistant::Service) do
+        before_execute do
+          add_log(level: :info, source: :hook, detail: :marker, message: 'from before')
+        end
+        def execute = :ok
+      end
+
+      instance = klass.new
+      instance.run
+
+      assert(instance.infos.any? { |l| l.message == 'from before' })
+    end
+
+    # ---- after_execute ----
+
+    def test_after_execute_runs_after_execute_with_result_and_service_self
+      seen = []
+      klass = Class.new(Assistant::Service) do
+        after_execute { |result| seen << [:after, result, self] }
+        def execute = :the_result
+      end
+
+      instance = klass.new
+      instance.run
+
+      assert_equal [:after, :the_result, instance], seen.first
+    end
+
+    def test_multiple_after_execute_hooks_run_in_declaration_order
+      seen = []
+      klass = Class.new(Assistant::Service) do
+        after_execute { |_r| seen << :first }
+        after_execute { |_r| seen << :second }
+        after_execute { |_r| seen << :third }
+        def execute = :ok
+      end
+
+      klass.run
+
+      assert_equal %i[first second third], seen
+    end
+
+    # ---- around_execute ----
+
+    def test_around_execute_can_wrap_execute_and_return_modified_value
+      klass = Class.new(Assistant::Service) do
+        around_execute do |&blk|
+          inner = blk.call
+          inner.to_s.upcase
+        end
+        def execute = 'hello'
+      end
+
+      outcome = klass.run
+
+      assert_equal 'HELLO', outcome[:result]
+    end
+
+    def test_around_execute_has_service_as_self_and_yields_to_execute
+      seen = []
+      klass = Class.new(Assistant::Service) do
+        around_execute do |&blk|
+          seen << [:around_in, self]
+          inner = blk.call
+          seen << [:around_out, self, inner]
+          inner
+        end
+        define_method(:execute) do
+          seen << [:execute, self]
+          :ok
+        end
+      end
+
+      instance = klass.new
+      instance.run
+
+      assert_equal :around_in,  seen[0][0]
+      assert_equal :execute,    seen[1][0]
+      assert_equal :around_out, seen[2][0]
+      assert_same instance, seen[0][1]
+      assert_same instance, seen[1][1]
+      assert_same instance, seen[2][1]
+      assert_equal :ok, seen[2][2]
+    end
+
+    def test_around_execute_declaration_order_wraps_first_is_outermost
+      seen = []
+      klass = Class.new(Assistant::Service) do
+        around_execute do |&blk|
+          seen << :a_in
+          blk.call
+          seen << :a_out
+        end
+        around_execute do |&blk|
+          seen << :b_in
+          blk.call
+          seen << :b_out
+        end
+        define_method(:execute) { seen << :execute }
+      end
+
+      klass.run
+
+      assert_equal %i[a_in b_in execute b_out a_out], seen
+    end
+
+    def test_around_execute_chain_composes_with_before_and_after
+      seen = []
+      klass = Class.new(Assistant::Service) do
+        before_execute { seen << :before }
+        around_execute do |&blk|
+          seen << :around_in
+          blk.call
+          seen << :around_out
+        end
+        after_execute { |_r| seen << :after }
+        define_method(:execute) { seen << :execute }
+      end
+
+      klass.run
+
+      assert_equal %i[before around_in execute around_out after], seen
+    end
+
+    # ---- Error semantics (M-S1 spec) ----
+
+    def test_before_execute_exception_is_logged_and_does_not_propagate
+      klass = Class.new(Assistant::Service) do
+        before_execute { raise 'before boom' }
+        def execute = :ok
+      end
+
+      instance = klass.new
+      outcome = instance.run
+
+      hook_errors = instance.errors.select { |l| l.source == :hook }
+
+      assert_equal 1, hook_errors.size
+      assert_equal :before_execute, hook_errors.first.detail
+      assert_match(/before boom/, hook_errors.first.message)
+      assert_equal :with_errors, outcome[:status]
+    end
+
+    def test_after_execute_exception_is_logged_and_does_not_propagate
+      klass = Class.new(Assistant::Service) do
+        after_execute { |_r| raise 'after boom' }
+        def execute = :ok
+      end
+
+      instance = klass.new
+      outcome = instance.run
+
+      hook_errors = instance.errors.select { |l| l.source == :hook }
+
+      assert_equal 1, hook_errors.size
+      assert_equal :after_execute, hook_errors.first.detail
+      assert_match(/after boom/, hook_errors.first.message)
+      assert_equal :with_errors, outcome[:status]
+    end
+
+    def test_around_execute_exception_is_logged_and_does_not_propagate
+      klass = Class.new(Assistant::Service) do
+        around_execute { |&_blk| raise 'around boom' }
+        def execute = :ok
+      end
+
+      instance = klass.new
+      outcome = instance.run
+
+      hook_errors = instance.errors.select { |l| l.source == :hook }
+
+      assert_equal 1, hook_errors.size
+      assert_equal :around_execute, hook_errors.first.detail
+      assert_match(/around boom/, hook_errors.first.message)
+      assert_equal :with_errors, outcome[:status]
+    end
+
+    def test_hook_error_log_uses_source_hook
+      klass = Class.new(Assistant::Service) do
+        before_execute { raise 'boom' }
+        def execute = :ok
+      end
+
+      instance = klass.new
+      instance.run
+
+      assert(instance.errors.any? { |l| l.source == :hook })
+    end
+
+    def test_hook_error_log_includes_exception_class_in_message
+      klass = Class.new(Assistant::Service) do
+        before_execute { raise ArgumentError, 'bad arg' }
+        def execute = :ok
+      end
+
+      instance = klass.new
+      instance.run
+
+      hook_log = instance.errors.find { |l| l.source == :hook }
+
+      assert_includes hook_log.message, 'ArgumentError'
+      assert_includes hook_log.message, 'bad arg'
+    end
+
+    def test_hook_error_log_preserves_backtrace_on_trace
+      klass = Class.new(Assistant::Service) do
+        before_execute { raise 'boom' }
+        def execute = :ok
+      end
+
+      instance = klass.new
+      instance.run
+
+      hook_log = instance.errors.find { |l| l.source == :hook }
+
+      assert_kind_of Array, hook_log.trace
+      refute_empty hook_log.trace
+    end
+
+    def test_one_before_hook_raising_does_not_skip_subsequent_before_hooks
+      seen = []
+      klass = Class.new(Assistant::Service) do
+        before_execute do
+          seen << :one
+          raise 'one boom'
+        end
+        before_execute { seen << :two }
+        before_execute { seen << :three }
+        def execute = :ok
+      end
+
+      klass.run
+
+      assert_equal %i[one two three], seen
+    end
+
+    def test_one_after_hook_raising_does_not_skip_subsequent_after_hooks
+      seen = []
+      klass = Class.new(Assistant::Service) do
+        after_execute do |_r|
+          seen << :one
+          raise 'one boom'
+        end
+        after_execute { |_r| seen << :two }
+        after_execute { |_r| seen << :three }
+        def execute = :ok
+      end
+
+      klass.run
+
+      assert_equal %i[one two three], seen
+    end
+
+    def test_around_hook_that_raises_before_continuation_skips_execute_for_that_layer
+      seen = []
+      klass = Class.new(Assistant::Service) do
+        around_execute do |&_blk|
+          seen << :raising
+          raise 'before continuation'
+        end
+        define_method(:execute) { seen << :execute }
+      end
+
+      klass.run
+
+      assert_equal [:raising], seen
+    end
+
+    def test_outer_around_hooks_still_wrap_when_inner_around_raises
+      seen = []
+      klass = Class.new(Assistant::Service) do
+        around_execute do |&blk|
+          seen << :outer_in
+          blk.call
+          seen << :outer_out
+        end
+        around_execute do |&_blk|
+          seen << :inner_raising
+          raise 'inner boom'
+        end
+        define_method(:execute) { seen << :execute }
+      end
+
+      klass.run
+
+      assert_equal %i[outer_in inner_raising outer_out], seen
+    end
+
+    def test_execute_exception_propagates_through_hook_chain
+      klass = Class.new(Assistant::Service) do
+        def execute = raise('execute boom')
+      end
+
+      assert_raises(RuntimeError) { klass.run }
+    end
+
+    # ---- Inheritance ----
+
+    def test_subclass_inherits_parent_before_hooks
+      seen = []
+      parent = Class.new(Assistant::Service) do
+        before_execute { seen << :parent_before }
+        def execute = :ok
+      end
+      child = Class.new(parent)
+
+      child.run
+
+      assert_equal [:parent_before], seen
+    end
+
+    def test_subclass_inherits_parent_around_and_after_hooks_in_order
+      seen = []
+      parent = Class.new(Assistant::Service) do
+        around_execute do |&blk|
+          seen << :parent_around_in
+          blk.call
+          seen << :parent_around_out
+        end
+        after_execute { |_r| seen << :parent_after }
+        define_method(:execute) { seen << :execute }
+      end
+      child = Class.new(parent)
+
+      child.run
+
+      assert_equal %i[parent_around_in execute parent_around_out parent_after], seen
+    end
+
+    def test_subclass_can_add_hooks_in_addition_to_inherited_ones
+      seen = []
+      parent = Class.new(Assistant::Service) do
+        before_execute { seen << :parent_before }
+        def execute = :ok
+      end
+      child = Class.new(parent) do
+        before_execute { seen << :child_before }
+      end
+
+      child.run
+
+      assert_equal %i[parent_before child_before], seen
+    end
+
+    def test_adding_hook_to_subclass_does_not_affect_parent
+      seen = []
+      parent = Class.new(Assistant::Service) do
+        def execute = :ok
+      end
+      Class.new(parent) do
+        before_execute { seen << :child_only }
+      end
+
+      parent.run
+
+      assert_empty seen
+    end
+
+    def test_adding_hook_to_parent_after_subclass_definition_does_not_affect_subclass
+      parent = Class.new(Assistant::Service) do
+        def execute = :ok
+      end
+      child = Class.new(parent)
+      parent.before_execute { raise 'should not run on child' }
+
+      instance = child.new
+      outcome = instance.run
+
+      # Child snapshotted parent's (empty) hook list at definition time,
+      # so the parent's later-added before_execute is invisible to it.
+      assert_empty instance.errors
+      assert_equal :ok, outcome[:status]
+    end
+
+    # ---- result memoization + no-hooks path ----
+
+    def test_calling_result_directly_runs_hooks_once
+      call_count = 0
+      klass = Class.new(Assistant::Service) do
+        before_execute { call_count += 1 }
+        def execute = :ok
+      end
+
+      instance = klass.new
+      instance.result
+      instance.result
+      instance.result
+
+      assert_equal 1, call_count
+    end
+
+    def test_service_without_hooks_executes_normally
+      klass = Class.new(Assistant::Service) do
+        def execute = 42
+      end
+
+      outcome = klass.run
+
+      assert_equal 42, outcome[:result]
+      assert_equal :ok, outcome[:status]
+    end
+  end
+end


### PR DESCRIPTION
Builds the next Must-have from the v1 roadmap: class-level callback DSL for wrapping `#execute` with reusable instrumentation, timing, locking, or transaction logic — without subclassing or monkey-patching.

Spec source: `docs/v1/02-features.md` M-S1 (lines 633-649), `docs/v1/01-api-surface.md:145-157` (canonical surface, Status Frozen).

## What ships

### Surface
Three new class-level methods on `Assistant::Service`, supplied by the new `Assistant::ExecuteCallbacks` mixin (included alongside `Assistant::InputBuilder` in `class << self`):

```ruby
class MyService < Assistant::Service
  before_execute  { add_log(level: :info, ...) }
  after_execute   { |result| add_log(level: :info, ...) }
  around_execute  { |&blk| Telemetry.time('svc') { blk.call } }
end
```

- All three require a block; calling without one raises `ArgumentError`.
- Hooks are stored as `UnboundMethod`s bound to anonymous `Module`s so the user's block runs with `self` == the service instance AND around hooks still receive the continuation as a real block argument (`&blk`) — something `instance_exec` alone cannot offer.
- **Inheritance:** at subclass-definition time each hook array is `dup`'d into the subclass. Adding more hooks to the parent later does not bleed into existing subclasses, and vice versa.

### Execution order
After validation, `#run` lazily triggers `#result`, which now flows through `run_execute_with_callbacks`:
1. `before_execute` hooks fire in declaration order.
2. The around chain fires inside-out: the first-declared `around_execute` is the **outermost** layer; each layer calls its continuation (`blk.call`) to descend.
3. `after_execute` hooks fire in declaration order with the execute result as the single positional arg.

### Error semantics (per the spec)
`StandardError` raised inside any hook is caught and logged via:
\`\`\`ruby
add_log(level: :error, source: :hook, detail: <hook_type>, message: '<ErrorClass>: <message>', trace: backtrace)
\`\`\`
The exception never propagates out of `#run`. Subsequent hooks of the same type still fire. An around hook that raises **before** calling its continuation suppresses its inner stack (including `#execute`) and returns `nil` from its layer; outer hooks still wrap normally.

A hook-logged error downgrades the terminal lifecycle event (coordinated with M-S3) from `:service_executed` to `:service_failed` and turns the run payload into `{ errors:, result: nil, status: :with_errors }`. The actual execute return value remains memoized and reachable via `instance.result` for callers who want both.

Non-`StandardError` exceptions (`SystemExit`, `Interrupt`, etc.) intentionally propagate, matching `Service#execute`'s own exception contract.

## Implementation notes
- `ExecuteCallbacks` uses `Module.new` + `define_method` to wrap each hook block, then exports it as an `UnboundMethod`. `um.bind_call(service, *args, &cont)` gives us bound-`self` + block-passing in one call — the only combination that satisfies the around contract without lambda gymnastics.
- `run_around_execute_chain` folds with `reverse_each` so the array ordering matches the documented \"declaration order wraps\" semantic; the per-layer lambda is extracted into `wrap_around_layer` to stay under the `Metrics/MethodLength` budget.
- `Service#run` now triggers `#result` eagerly (after the validation short-circuit) so a hook-logged error is visible to the branch that picks `executed_payload` vs `failed_payload` and to the `:service_executed` / `:service_failed` M-S3 event. The validation-failure short-circuit (`return failed_payload if errors.any?`) preserves the existing fast-fail behavior.

## Coverage
+38 Minitest cases in `test/assistant/execute_callbacks_test.rb` covering:
- DSL surface (block required, `ArgumentError` otherwise).
- Declaration ordering for all three hook types.
- Around composition (`outer_in`, `inner_in`, `execute`, `inner_out`, `outer_out`).
- Mixed before/around/after stacks.
- `self`-binding inside each hook type.
- Error containment (hook error is logged with `source: :hook` and the hook type as `detail`, exception class in `message`, backtrace on `trace`).
- Subsequent hooks still run after one raises.
- Around hook raising before continuation suppresses inner stack but outer hooks still wrap.
- `#execute` exceptions propagate unchanged.
- Inheritance snapshot semantics (subclass inherits; subclass additions don't affect parent; parent additions after subclass definition don't affect subclass).
- Result memoization (hooks fire once even when `#result` is called repeatedly).

## Gates
- `bundle exec rake test` — 193 runs / 538 assertions / 0 failures.
- `bundle exec rubocop` — clean (40 files inspected).
- `bundle exec steep check` — no type errors (lib target).

## Roadmap delta
- `docs/v1/02-features.md` M-S1 status flipped `[ ]` → `[x]`.
- `CHANGELOG.md` `[Unreleased]` / `### Added` entry added at the top of the section, above the M-S3 entry from PR #153.

## .rubocop.yml additions
- `Service` class gets an inline `Metrics/ClassLength` disable; the core class is approaching the 100-line limit but every method has a single responsibility.
- `Metrics/AbcSize` is now excluded for `test/**/*.rb` (same rationale as the pre-existing `Metrics/MethodLength` and `Metrics/BlockLength` test exclusions: anonymous `Class.new` blocks inflate ABC counts without reflecting real branching complexity).

Stacks cleanly on top of merged PRs #152 (M4/M6 status flip) and #153 (M-S3 notifier). Unblocks the next Must items: M-S2 `call_service` composition primitive, M-S4 frozen `Data` input snapshot, then M12 keyword-only sweep last.