### PR TITLE
M-S2: add Service#call_service composition primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Assistant::Service#call_service(klass, **inputs)` — instance-level
+  helper for composing services. Constructs an instance of `klass`
+  (asserted to be an `Assistant::Service` subclass; raises
+  `ArgumentError` otherwise), invokes `inner.run`, merges the inner
+  service's full log timeline (info + warning + error) onto the outer
+  service via `merge_logs`, and returns the inner instance. Because
+  `Service#errors` / `#warnings` / `#status` are derived by filtering
+  `@logs`, inner errors automatically downgrade the outer terminal
+  status to `:with_errors` and inner warnings surface as
+  `:with_warnings` (when no errors are present), without any branching
+  in the caller. Exceptions raised by the inner service's `#execute`
+  or by `Assistant.notifier` are not rescued; they propagate to the
+  caller, matching the base `Service#run` contract. The inner service
+  fires its own `:service_started`/`:service_validated`/
+  `:service_executed`/`:service_failed` events independently of the
+  outer lifecycle. (M-S2, v1 plan)
+
 - `before_execute`, `after_execute { |result| }`, and
   `around_execute { |&blk| ... }` class-level DSL on
   `Assistant::Service` for wrapping `#execute` with reusable hooks.

--- a/docs/v1/02-features.md
+++ b/docs/v1/02-features.md
@@ -670,7 +670,7 @@ documented to avoid surprise.
   status becomes `:with_errors` automatically.
 - **Risk**: medium. Need to be explicit about whether warnings propagate
   (yes) and whether errors are translated (no — they're appended verbatim).
-- **Status**: `[ ]`.
+- **Status**: `[x]` — shipped on `feature/m-s2-call-service`.
 
 ### M-S3. Instrumentation hook
 

--- a/lib/assistant/service.rb
+++ b/lib/assistant/service.rb
@@ -63,6 +63,46 @@ module Assistant
       warnings.empty? ? :ok : :with_warnings
     end
 
+    # M-S2: instantiate `klass`, run it, merge its log timeline into the
+    # current service, and return the inner service instance.
+    #
+    # The full log timeline of the inner service (info + warning +
+    # error) is concatenated onto the outer service's `@logs` via
+    # `merge_logs`. Because the outer service's `errors`, `warnings`,
+    # and `status` are derived by filtering `@logs`, an inner error
+    # automatically downgrades the outer terminal status to
+    # `:with_errors`, and inner warnings surface as `:with_warnings`
+    # when no errors are present — without any special handling in
+    # the caller.
+    #
+    # The returned inner instance exposes `#result`, `#success?`,
+    # `#failure?`, etc. so the caller can branch on the inner outcome:
+    #
+    #   def execute
+    #     other = call_service(OtherService, foo: 1)
+    #     return if failure?
+    #     other.result + 1
+    #   end
+    #
+    # `call_service` does **not** rescue exceptions raised by the inner
+    # service's `#execute` or by `Assistant.notifier`; those propagate
+    # to the caller, matching the base `Service#run` contract. To run
+    # an inner service that may raise, wrap the call in a `begin/rescue`
+    # and use `add_log(level: :error, …)` to record the failure.
+    #
+    # Raises `ArgumentError` if `klass` is not an `Assistant::Service`
+    # subclass — the check happens before any instance is constructed.
+    def call_service(klass, **inputs)
+      unless klass.is_a?(Class) && klass <= Assistant::Service
+        raise ArgumentError, "call_service expects an Assistant::Service subclass, got #{klass.inspect}"
+      end
+
+      inner = klass.new(**inputs)
+      inner.run
+      merge_logs(inner.logs)
+      inner
+    end
+
     private
 
     # Build the success-path result hash and fire the terminal

--- a/lib/assistant/service.rbs
+++ b/lib/assistant/service.rbs
@@ -36,6 +36,11 @@ class Assistant::Service
 
   def status: () -> Symbol
 
+  # M-S2: run a child `Assistant::Service` subclass, merge its log
+  # timeline into `self`, return the inner instance. Raises
+  # ArgumentError if `klass` is not an `Assistant::Service` subclass.
+  def call_service: (Class klass, **untyped inputs) -> Assistant::Service
+
   private
 
   attr_reader inputs: Hash[Symbol, untyped]

--- a/test/assistant/service_test.rb
+++ b/test/assistant/service_test.rb
@@ -342,5 +342,193 @@ module Assistant
 
       assert_empty stderr
     end
+
+    # ---- M-S2: call_service composition ----
+
+    def build_doubler_service
+      Class.new(Assistant::Service) do
+        input :n, type: Integer, required: true
+        def execute = n * 2
+      end
+    end
+
+    def build_warner_service
+      Class.new(Assistant::Service) do
+        def validate
+          add_log(level: :warning, source: :validate, detail: :slow, message: 'heads up')
+        end
+
+        def execute = :inner_ok
+      end
+    end
+
+    def test_call_service_returns_inner_service_instance
+      doubler = build_doubler_service
+      outer_class = Class.new(Assistant::Service)
+      outer_class.define_method(:execute) { call_service(doubler, n: 21) }
+
+      outer = outer_class.new
+      outer.run
+
+      assert_kind_of doubler, outer.result
+      assert_equal 42, outer.result.result
+    end
+
+    def test_call_service_passes_keyword_inputs_to_inner
+      doubler = build_doubler_service
+      outer_class = Class.new(Assistant::Service)
+      outer_class.define_method(:execute) { call_service(doubler, n: 7).result }
+
+      outcome = outer_class.run
+
+      assert_equal 14, outcome[:result]
+      assert_equal :ok, outcome[:status]
+    end
+
+    def test_call_service_merges_inner_logs_into_outer
+      warner = build_warner_service
+      outer_class = Class.new(Assistant::Service)
+      outer_class.define_method(:execute) { call_service(warner) }
+
+      outer = outer_class.new
+      outer.run
+
+      assert_equal 1, outer.logs.size
+      assert_equal :warning, outer.logs.first.level
+      assert_equal 'heads up', outer.logs.first.message
+    end
+
+    def test_call_service_inner_warning_propagates_to_with_warnings_status
+      warner = build_warner_service
+      outer_class = Class.new(Assistant::Service)
+      outer_class.define_method(:execute) { call_service(warner) }
+
+      outcome = outer_class.run
+
+      assert_equal :with_warnings, outcome[:status]
+      assert_equal 1, outcome[:warnings].size
+    end
+
+    def test_call_service_inner_error_propagates_to_with_errors_status
+      doubler = build_doubler_service
+      outer_class = Class.new(Assistant::Service)
+      outer_class.define_method(:execute) { call_service(doubler) } # missing required :n
+
+      outcome = outer_class.run
+
+      assert_equal :with_errors, outcome[:status]
+      assert_nil outcome[:result]
+      refute_empty outcome[:errors]
+    end
+
+    def test_call_service_outer_failure_predicate_reflects_inner_error
+      doubler = build_doubler_service
+      outer_class = Class.new(Assistant::Service)
+      outer_class.define_method(:execute) do
+        call_service(doubler) # missing :n -> inner failure
+        :outer_executed
+      end
+
+      outer = outer_class.new
+      outer.run
+
+      assert_predicate outer, :failure?
+    end
+
+    def test_call_service_allows_early_return_pattern_from_features_doc
+      doubler = build_doubler_service
+      outer_class = Class.new(Assistant::Service)
+      outer_class.define_method(:execute) do
+        inner = call_service(doubler) # missing :n -> failure
+        return if failure?
+
+        inner.result + 1
+      end
+
+      outcome = outer_class.run
+
+      assert_equal :with_errors, outcome[:status]
+      assert_nil outcome[:result]
+    end
+
+    def test_call_service_log_order_preserves_outer_then_inner_then_outer
+      doubler = build_doubler_service
+      outer_class = Class.new(Assistant::Service)
+      outer_class.define_method(:execute) do
+        add_log(level: :info, source: :execute, detail: :before, message: 'pre')
+        call_service(doubler, n: 1)
+        add_log(level: :info, source: :execute, detail: :after, message: 'post')
+      end
+
+      outer = outer_class.new
+      outer.run
+
+      # inner doubler logs nothing, so only the two outer infos are present
+      assert_equal %i[before after], outer.logs.map(&:detail)
+    end
+
+    def test_call_service_multiple_inner_errors_all_propagate
+      doubler = build_doubler_service
+      outer_class = Class.new(Assistant::Service)
+      outer_class.define_method(:execute) do
+        call_service(doubler) # error 1
+        call_service(doubler) # error 2
+      end
+
+      outcome = outer_class.run
+
+      assert_equal :with_errors, outcome[:status]
+      assert_equal 2, outcome[:errors].size
+    end
+
+    def test_call_service_with_non_class_raises_argument_error
+      outer = Assistant::Service.new
+      error = assert_raises(ArgumentError) { outer.send(:call_service, :not_a_class) }
+
+      assert_match(/Assistant::Service subclass/, error.message)
+    end
+
+    def test_call_service_with_non_service_class_raises_argument_error
+      outer = Assistant::Service.new
+      error = assert_raises(ArgumentError) { outer.send(:call_service, String) }
+
+      assert_match(/Assistant::Service subclass/, error.message)
+    end
+
+    def test_call_service_with_service_base_class_itself_is_allowed
+      outer_class = Class.new(Assistant::Service)
+      outer_class.define_method(:execute) { call_service(Assistant::Service) }
+
+      outcome = outer_class.run
+
+      assert_equal :ok, outcome[:status]
+    end
+
+    def test_call_service_does_not_swallow_inner_execute_exceptions
+      raiser = Class.new(Assistant::Service) do
+        def execute = raise 'inner boom'
+      end
+
+      outer_class = Class.new(Assistant::Service)
+      outer_class.define_method(:execute) { call_service(raiser) }
+
+      assert_raises(RuntimeError) { outer_class.run }
+    end
+
+    def test_call_service_inner_notifier_events_fire_independently
+      events = with_recording_notifier
+      doubler = build_doubler_service
+      outer_class = Class.new(Assistant::Service)
+      outer_class.define_method(:execute) { call_service(doubler, n: 1) }
+
+      outer_class.run
+
+      # outer: started, validated, executed; inner: started, validated, executed.
+      # Notifier sees both lifecycles, ordered by emission.
+      assert_equal 6, events.size
+      assert_equal %i[service_started service_validated service_started service_validated
+                      service_executed service_executed],
+                   events.map(&:first)
+    end
   end
 end


### PR DESCRIPTION
## Scope

Implements **M-S2** from the v1 roadmap
(`docs/v1/02-features.md` — Service composition primitive). This is
one of the last two Must-list items blocking M12 (keyword-args sweep);
only M-S4 (`#input_snapshot`) remains.

## What this PR ships

- `Assistant::Service#call_service(klass, **inputs) -> Assistant::Service`
  on `lib/assistant/service.rb`. Constructs an inner service, runs
  it, merges the inner's full log timeline (info + warning + error)
  via `merge_logs`, and returns the inner instance for further
  inspection (`inner.result`, `inner.success?`, etc.).
- Status propagation is implicit: because `Service#errors`,
  `#warnings`, and `#status` are derived by filtering `@logs`, inner
  errors automatically yield `:with_errors` on the outer service and
  inner warnings yield `:with_warnings` (when no errors are present)
  — without any branching in the caller.
- Soft-fail boundary preserved: `StandardError` from the inner
  `#execute` or from `Assistant.notifier` is **not** rescued; it
  propagates, matching the base `Service#run` contract.
- `ArgumentError` is raised before any instance is built when `klass`
  is not an `Assistant::Service` subclass (`is_a?(Class) && <= Service`).
- Hand-written RBS in `lib/assistant/service.rbs`.
- 15 new Minitest cases in `test/assistant/service_test.rb` covering
  the success path, keyword-arg passthrough, log merging, warning and
  error status propagation, the early-return pattern from the
  features doc, log ordering, multiple inner errors, ArgumentError
  guards, the base-class allowed case, exception passthrough, and the
  inner-notifier-events-fire-independently invariant.
- Roadmap status for M-S2 flipped to \`[x]\` in
  \`docs/v1/02-features.md\`.
- \`CHANGELOG.md\` entry under \`[Unreleased] → Added\`.

## Sample usage

\`\`\`ruby
class Outer < Assistant::Service
  def execute
    inner = call_service(Doubler, n: 21)
    return if failure?
    inner.result + 1   # => 43
  end
end
\`\`\`

If \`Doubler\` logs a warning, \`Outer.run\` returns
\`{ result: 43, status: :with_warnings, warnings: [<inner warning>] }\`.
If \`Doubler\` fails its required-input check, \`Outer.run\` returns
\`{ errors: [<inner error>], result: nil, status: :with_errors }\`
without any extra plumbing.

## Verification

\`\`\`
$ bundle exec rake test
207 runs, 568 assertions, 0 failures, 0 errors, 0 skips

$ bundle exec rubocop
40 files inspected, no offenses detected

$ bundle exec steep check --jobs=1
No type error detected.
\`\`\`

## Out of scope

- M12 (keyword-only sweep) will rewrite this signature to
  \`call_service(klass:, **inputs:)\` and the internal
  \`merge_logs(other_logs)\` call site to \`merge_logs(logs:)\`. M-S2
  intentionally lands with the positional \`klass\` form documented
  in \`docs/v1/01-api-surface.md\` so M12 stays a single mechanical
  signature pass.
- M-S4 (\`Service#input_snapshot\`) and M12 follow as the last two
  v1 Must items.