### PR TITLE
M-S4: Service#input_snapshot frozen Data view of declared inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Assistant::Service#input_snapshot` — returns a frozen `Data`
+  instance whose members are the declared input names (via
+  `Service.input` / `Service.inputs`), in declaration order, with
+  values read from `@inputs` after `apply_input_defaults` has run. The
+  snapshot therefore reflects post-`default:` and post-`allow_nil:`
+  values, matching what the per-input getters expose. Only declared
+  inputs appear; extra keyword arguments accepted by `#initialize`
+  (which live in `@inputs` but have no `input :foo` declaration) are
+  intentionally excluded so the snapshot's shape mirrors the public
+  DSL. A declared input with no default and no caller-supplied value
+  surfaces as `nil`. The returned `Data` is structurally immutable
+  (no member reassignment); member values that are themselves mutable
+  (e.g. an `Array`) keep their normal mutability — the snapshot does
+  not deep-freeze. Each call returns a fresh `Data` instance backed
+  by a per-subclass `Data` class memoised on
+  `Service.input_snapshot_class` (rebuilt transparently if the
+  subclass declares more inputs after the first snapshot call).
+  Useful for passing a read-only view of inputs to helpers,
+  collaborators, or test assertions without exposing the mutable
+  `@inputs` hash.
+
 - `Assistant::Service#call_service(klass, **inputs)` — instance-level
   helper for composing services. Constructs an instance of `klass`
   (asserted to be an `Assistant::Service` subclass; raises

--- a/docs/v1/02-features.md
+++ b/docs/v1/02-features.md
@@ -691,7 +691,7 @@ documented to avoid surprise.
   read-only snapshot of inputs they can pass around safely.
 - **API sketch**: `Service#input_snapshot -> Data.define(*declared_input_names).new(...)`.
 - **Risk**: medium — interacts with M1 (defaults) and M2 (allow_nil).
-- **Status**: `[ ]`.
+- **Status**: `[x]`.
 
 ---
 

--- a/lib/assistant/service.rb
+++ b/lib/assistant/service.rb
@@ -22,6 +22,19 @@ module Assistant
       def run(**)
         new(**).run
       end
+
+      # M-S4: per-subclass `Data` class whose members are the declared
+      # input names, in declaration order. Memoised on the subclass and
+      # transparently rebuilt if `input_definitions` changes (e.g. a
+      # late `input :foo` after the first snapshot call). Used by
+      # `Service#input_snapshot`; users normally never touch it.
+      def input_snapshot_class
+        keys = input_definitions.keys
+        return @input_snapshot_class if @input_snapshot_class && @input_snapshot_class_keys == keys
+
+        @input_snapshot_class_keys = keys
+        @input_snapshot_class = Data.define(*keys)
+      end
     end
 
     def initialize(**args)
@@ -101,6 +114,39 @@ module Assistant
       inner.run
       merge_logs(inner.logs)
       inner
+    end
+
+    # M-S4: a read-only `Data` view over the declared inputs of this
+    # service, post-`default:` / post-`allow_nil:`. Members are the
+    # input names declared via `Service.input` / `Service.inputs`, in
+    # declaration order; values are read from `@inputs` after
+    # `apply_input_defaults` has run, so callers see the same values
+    # the per-input getters expose.
+    #
+    #   class Greet < Assistant::Service
+    #     input :name, type: String, required: true
+    #     input :loud, type: TrueClass, default: false
+    #   end
+    #
+    #   Greet.new(name: 'Ada').input_snapshot
+    #   # => #<data name="Ada", loud=false>
+    #
+    # The returned object is a `Data` instance, so it is structurally
+    # immutable: no member can be reassigned. Member values that are
+    # themselves mutable (e.g. an `Array` passed as an input) keep
+    # their normal mutability — the snapshot does not deep-freeze.
+    #
+    # Only declared inputs appear in the snapshot. Extra keyword
+    # arguments accepted by `#initialize` (which live in `@inputs`
+    # but have no `input :foo` declaration) are intentionally excluded
+    # so the snapshot's shape matches the public DSL.
+    #
+    # A declared input with no default and no caller-supplied value
+    # appears with a `nil` member value, mirroring the behaviour of
+    # the per-input getter.
+    def input_snapshot
+      keys = self.class.input_definitions.keys
+      self.class.input_snapshot_class.new(**keys.to_h { |name| [name, @inputs[name]] })
     end
 
     private

--- a/lib/assistant/service.rbs
+++ b/lib/assistant/service.rbs
@@ -24,6 +24,10 @@ class Assistant::Service
 
   def self.run: (**untyped) -> Hash[Symbol, untyped]
 
+  # M-S4: per-subclass Data class whose members are the declared input
+  # names. Memoised; rebuilt when `input_definitions` changes.
+  def self.input_snapshot_class: () -> Class
+
   def initialize: (**untyped) -> void
 
   def run: () -> Hash[Symbol, untyped]
@@ -40,6 +44,11 @@ class Assistant::Service
   # timeline into `self`, return the inner instance. Raises
   # ArgumentError if `klass` is not an `Assistant::Service` subclass.
   def call_service: (Class klass, **untyped inputs) -> Assistant::Service
+
+  # M-S4: read-only Data view over declared inputs, post-default and
+  # post-allow_nil. Only declared inputs are members; undeclared
+  # kwargs from `#initialize` are excluded.
+  def input_snapshot: () -> Data
 
   private
 

--- a/test/assistant/service_test.rb
+++ b/test/assistant/service_test.rb
@@ -530,5 +530,173 @@ module Assistant
                       service_executed service_executed],
                    events.map(&:first)
     end
+
+    # ---- M-S4: input_snapshot ----
+
+    def test_input_snapshot_returns_data_instance_with_declared_members
+      klass = Class.new(Assistant::Service) do
+        input :name, type: String, required: true
+        input :age,  type: Integer
+      end
+
+      snapshot = klass.new(name: 'Ada', age: 37).input_snapshot
+
+      assert_kind_of Data, snapshot
+      assert_equal 'Ada', snapshot.name
+      assert_equal 37, snapshot.age
+    end
+
+    def test_input_snapshot_preserves_declaration_order
+      klass = Class.new(Assistant::Service) do
+        input :z, type: Integer
+        input :a, type: Integer
+        input :m, type: Integer
+      end
+
+      snapshot = klass.new(z: 1, a: 2, m: 3).input_snapshot
+
+      assert_equal %i[z a m], snapshot.members
+    end
+
+    def test_input_snapshot_is_structurally_immutable
+      klass = Class.new(Assistant::Service) do
+        input :n, type: Integer
+      end
+
+      snapshot = klass.new(n: 1).input_snapshot
+
+      assert_predicate snapshot, :frozen?
+      assert_raises(NoMethodError) { snapshot.n = 2 }
+    end
+
+    def test_input_snapshot_reflects_m1_defaults
+      klass = Class.new(Assistant::Service) do
+        input :limit, type: Integer, default: 25
+        input :now,   type: Time,    default: -> { Time.utc(2024, 1, 1) }
+      end
+
+      snapshot = klass.new.input_snapshot
+
+      assert_equal 25, snapshot.limit
+      assert_equal Time.utc(2024, 1, 1), snapshot.now
+    end
+
+    def test_input_snapshot_with_m2_allow_nil_keeps_explicit_nil
+      klass = Class.new(Assistant::Service) do
+        input :note, type: String, allow_nil: true
+      end
+
+      snapshot = klass.new(note: nil).input_snapshot
+
+      assert_nil snapshot.note
+    end
+
+    def test_input_snapshot_with_m1_default_and_m2_allow_nil_explicit_nil_skips_default
+      # M1's shipped semantics (see CHANGELOG M1 entry): with
+      # `allow_nil: true`, an explicit `nil` from the caller is
+      # honoured and the default is skipped. The snapshot reflects
+      # that post-`apply_input_defaults` value.
+      klass = Class.new(Assistant::Service) do
+        input :note, type: String, default: 'hi', allow_nil: true
+      end
+
+      assert_nil klass.new(note: nil).input_snapshot.note
+      assert_equal 'hi', klass.new.input_snapshot.note
+    end
+
+    def test_input_snapshot_excludes_undeclared_kwargs
+      klass = Class.new(Assistant::Service) do
+        input :declared, type: String
+      end
+
+      snapshot = klass.new(declared: 'yes', undeclared: 'no').input_snapshot
+
+      assert_equal %i[declared], snapshot.members
+      refute_respond_to snapshot, :undeclared
+    end
+
+    def test_input_snapshot_for_service_with_no_inputs_is_empty_data
+      snapshot = Assistant::Service.new.input_snapshot
+
+      assert_kind_of Data, snapshot
+      assert_empty snapshot.members
+    end
+
+    def test_input_snapshot_missing_required_input_appears_as_nil
+      # Snapshot can be called from validate or anywhere; it does not
+      # require successful #run. A missing required input simply
+      # surfaces as nil, matching the per-input getter behaviour.
+      klass = Class.new(Assistant::Service) do
+        input :name, type: String, required: true
+      end
+
+      snapshot = klass.new.input_snapshot
+
+      assert_nil snapshot.name
+    end
+
+    def test_input_snapshot_class_is_memoised_per_subclass
+      klass = Class.new(Assistant::Service) do
+        input :n, type: Integer
+      end
+
+      assert_same klass.input_snapshot_class, klass.input_snapshot_class
+    end
+
+    def test_input_snapshot_class_differs_between_subclasses
+      one = Class.new(Assistant::Service) { input :a, type: Integer }
+      two = Class.new(Assistant::Service) { input :b, type: Integer }
+
+      refute_same one.input_snapshot_class, two.input_snapshot_class
+    end
+
+    def test_input_snapshot_class_rebuilds_when_definitions_change
+      klass = Class.new(Assistant::Service)
+      klass.input :a, type: Integer
+      first = klass.input_snapshot_class
+
+      klass.input :b, type: Integer
+      second = klass.input_snapshot_class
+
+      refute_same first, second
+      assert_equal %i[a b], second.members
+    end
+
+    def test_input_snapshot_returns_fresh_instance_each_call
+      klass = Class.new(Assistant::Service) do
+        input :n, type: Integer
+      end
+      svc = klass.new(n: 1)
+
+      first = svc.input_snapshot
+      second = svc.input_snapshot
+
+      refute_same first, second
+      assert_equal first, second
+    end
+
+    def test_input_snapshot_values_share_object_identity_with_inputs
+      # Data is structurally immutable but does not deep-freeze members;
+      # a mutable input value is the same object in the snapshot.
+      mutable = [1, 2, 3]
+      klass = Class.new(Assistant::Service) do
+        input :xs, type: Array
+      end
+
+      snapshot = klass.new(xs: mutable).input_snapshot
+
+      assert_same mutable, snapshot.xs
+    end
+
+    def test_input_snapshot_callable_from_inside_execute
+      klass = Class.new(Assistant::Service) do
+        input :n, type: Integer, required: true
+        def execute = input_snapshot.n * 10
+      end
+
+      outcome = klass.run(n: 4)
+
+      assert_equal 40, outcome[:result]
+    end
   end
 end


### PR DESCRIPTION
## Scope

Ships **M-S4** from
[`docs/v1/02-features.md` lines 688-694](../blob/main/docs/v1/02-features.md#L688)
and the additive-changes table entry in
[`docs/v1/01-api-surface.md` lines 182-187](../blob/main/docs/v1/01-api-surface.md#L182).

## What this PR ships

- `Assistant::Service#input_snapshot -> Data` — returns a fresh `Data`
  instance whose members are the declared input names (via
  `Service.input` / `Service.inputs`) in declaration order, with values
  read from `@inputs` after `apply_input_defaults` has run. The
  snapshot therefore reflects post-`default:` / post-`allow_nil:`
  values, matching what the per-input getters expose.
- `Assistant::Service.input_snapshot_class` — per-subclass `Data` class
  memoised on the subclass and transparently rebuilt if `input_definitions`
  changes after the first snapshot call (e.g. a late `input :foo` declaration).
- RBS signatures updated for both methods.
- Only declared inputs appear in the snapshot. Extra keyword arguments
  accepted by `#initialize` (which live in `@inputs` but have no
  `input :foo` declaration) are intentionally excluded so the snapshot's
  shape mirrors the public DSL.
- A declared input with no default and no caller-supplied value surfaces
  as `nil`, mirroring the per-input getter.
- The returned `Data` is structurally immutable (no member reassignment).
  Mutable member values (e.g. an `Array` passed as an input) keep their
  normal mutability — the snapshot does not deep-freeze.

## Sample

\`\`\`ruby
class Greet < Assistant::Service
  input :name, type: String, required: true
  input :loud, type: TrueClass, default: false
end

Greet.new(name: 'Ada').input_snapshot
# => #<data name=\"Ada\", loud=false>

Greet.new(name: 'Ada').input_snapshot.frozen?
# => true

Greet.new(name: 'Ada').input_snapshot.name = 'Bob'
# NoMethodError: undefined method 'name=' ...
\`\`\`

## Verification

\`\`\`
\$ bundle exec rake test
222 runs, 594 assertions, 0 failures, 0 errors, 0 skips

\$ bundle exec rubocop
40 files inspected, no offenses detected

\$ bundle exec steep check --jobs=1
No type error detected. 🫖
\`\`\`

## Notes

- One test (\`test_input_snapshot_with_m1_default_and_m2_allow_nil_explicit_nil_skips_default\`)
  asserts M1's **shipped** behaviour from PR #137 / CHANGELOG: with
  \`allow_nil: true\`, an explicit \`nil\` from the caller is honoured and
  the default is **skipped**. This diverges from \`docs/v1/02-features.md\`
  M1 point 8 (which says the default should win). That's a pre-existing
  stale-doc bug, not an M-S4 concern; this PR doesn't touch it.

## Out of scope

- M12 keyword-args sweep — the final v1 Must item; lands separately and
  mechanically rewrites \`Service.input(:foo, …)\` →
  \`Service.input(name: :foo, …)\` and friends across the DSL.