### PR TITLE
D1: rewrite top-level README for the 1.0 launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **D1**: rewrote the top-level `README.md`. Replaced the bundler-template
+  `TODO:` placeholders and `[USERNAME]/assistant` URLs with an elevator
+  pitch, status badges (CI, gem version, downloads, Ruby version,
+  license), `bundle add` / `gem install` instructions, a runnable
+  60-second `CreateUser` example covering required inputs, defaults,
+  `allow_nil:`, `validate`, and the `log_item_warning` /
+  `log_item_error` shorthands, a "why another service-object gem?"
+  comparison against Interactor and dry-transaction, a documentation
+  index pointing at `docs/v1/01-api-surface.md`, the migration guide,
+  deprecations, examples, the changelog, and the roadmap, plus a
+  refreshed Development section listing `rake test`, `rubocop`, and
+  `steep check`. (D1, v1 plan)
+
 - `Assistant::Service#input_snapshot` — returns a frozen `Data`
   instance whose members are the declared input names (via
   `Service.input` / `Service.inputs`), in declaration order, with

--- a/README.md
+++ b/README.md
@@ -1,43 +1,147 @@
 # Assistant
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/assistant`. To experiment with that code, run `bin/console` for an interactive prompt.
+[![CI](https://github.com/ramongr/assistant/actions/workflows/ci.yml/badge.svg)](https://github.com/ramongr/assistant/actions/workflows/ci.yml)
+[![Gem Version](https://img.shields.io/gem/v/assistant.svg)](https://rubygems.org/gems/assistant)
+[![Downloads](https://img.shields.io/gem/dt/assistant.svg)](https://rubygems.org/gems/assistant)
+[![Ruby](https://img.shields.io/badge/ruby-%3E%3D%203.4-ruby.svg)](https://www.ruby-lang.org/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
-TODO: Delete this and the text above, and describe your gem
+A tiny, dependency-free Ruby library for writing **soft-fail, composable
+service objects**. A service declares its inputs, validates them, runs its
+body, and returns a uniform result that always carries either a value plus
+warnings or a list of errors — it never raises for expected failures.
 
 ## Installation
 
-Add this line to your application's Gemfile:
-
-```ruby
-gem 'assistant'
+```sh
+bundle add assistant
 ```
 
-And then execute:
+Or without Bundler:
 
-    $ bundle
+```sh
+gem install assistant
+```
 
-Or install it yourself as:
+Ruby `>= 3.4` is required.
 
-    $ gem install assistant
+## 60-second example
 
-## Usage
+```ruby
+require 'assistant'
 
-TODO: Write usage instructions here
+class CreateUser < Assistant::Service
+  input :email, type: String,  required: true
+  input :name,  type: String,  required: true
+  input :age,   type: Integer, allow_nil: true, default: nil
+
+  def validate
+    return if email.include?('@')
+
+    log_item_error(source: :validate, detail: :email, message: 'must contain @')
+  end
+
+  def execute
+    log_item_warning(source: :execute, detail: :age, message: 'age missing') if age.nil?
+
+    User.create!(email:, name:, age:)
+  end
+end
+
+CreateUser.run(email: 'ada@example.com', name: 'Ada')
+# => { result: #<User …>, status: :with_warnings, warnings: [#<Assistant::LogItem …>] }
+
+CreateUser.run(email: 'nope', name: 'Ada')
+# => { errors: [#<Assistant::LogItem …>], result: nil, status: :with_errors }
+```
+
+The result hash is always one of two shapes:
+
+```ruby
+# Success — status is :ok or :with_warnings
+{ result: <Object>, status: :ok | :with_warnings, warnings: Array<Assistant::LogItem> }
+
+# Failure — any error was logged before or during execute
+{ errors: Array<Assistant::LogItem>, result: nil, status: :with_errors }
+```
+
+Use `#success?`, `#failure?`, and `#status` on a service instance, or
+pattern-match the hash returned by `.run` directly.
+
+## Why another service-object gem?
+
+- **No runtime dependencies.** `assistant` is one require away; it does not
+  pull in ActiveSupport, dry-rb, or anything else. It runs in plain Ruby,
+  Rails, Hanami, Sidekiq workers, and Rake tasks alike.
+- **Soft-fail by design.** Validation problems and recoverable failures are
+  surfaced as `LogItem`s on the result, not exceptions. Callers
+  pattern-match a hash; they don't write `rescue` blocks for expected
+  outcomes.
+- **Tiny, frozen surface.** The public API documented in
+  [`docs/v1/01-api-surface.md`](docs/v1/01-api-surface.md) is everything
+  there is. No DSL gymnastics, no plug-in registry, no opinionated
+  serialization. Compose services with the plain `#call_service` primitive.
+
+Compared to [Interactor](https://github.com/collectiveidea/interactor) and
+[dry-transaction](https://dry-rb.org/gems/dry-transaction/), `assistant`
+keeps a single result shape regardless of success or failure, distinguishes
+warnings from errors at the log-item level, and ships RBS signatures plus
+a per-class generator (`bin/assistant-rbs`) out of the box.
+
+## Documentation
+
+- **API reference** — [`docs/v1/01-api-surface.md`](docs/v1/01-api-surface.md)
+  enumerates every public symbol with its stability label.
+- **Feature catalogue and rationale** —
+  [`docs/v1/02-features.md`](docs/v1/02-features.md).
+- **Upgrading from 0.x** —
+  [`docs/v1/06-migration-0x-to-1.md`](docs/v1/06-migration-0x-to-1.md).
+- **Deprecations** — [`docs/deprecations.md`](docs/deprecations.md).
+- **Runnable sample** — [`examples/greeter.rb`](examples/greeter.rb).
+- **Changelog** — [`CHANGELOG.md`](CHANGELOG.md).
+
+Longer user-facing guides (`docs/getting-started.md`,
+`docs/guides/*.md`) are tracked in
+[`docs/v1/03-documentation.md`](docs/v1/03-documentation.md) and land in
+follow-up PRs.
+
+## Roadmap
+
+The plan for the 1.0 release lives under
+[`docs/v1/`](docs/v1/README.md). Every "must" item is shipped; remaining
+work is documentation and release-checklist tasks.
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+```sh
+bin/setup                                  # install dependencies
+bundle exec rake test                      # Minitest
+bundle exec rubocop                        # style
+bundle exec steep check --jobs=1           # type-check RBS signatures
+bin/console                                # IRB session with the gem loaded
+```
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install the gem locally for ad-hoc experimentation:
+
+```sh
+bundle exec rake install
+```
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/assistant. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome at
+<https://github.com/ramongr/assistant>. This project is intended to be a
+safe, welcoming space for collaboration, and contributors are expected to
+adhere to the [Contributor Covenant](http://contributor-covenant.org) code
+of conduct.
 
 ## License
 
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+The gem is released under the terms of the
+[MIT License](https://opensource.org/licenses/MIT).
 
 ## Code of Conduct
 
-Everyone interacting in the Assistant project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/assistant/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the Assistant project's codebases, issue trackers,
+chat rooms, and mailing lists is expected to follow the
+[code of conduct](https://github.com/ramongr/assistant/blob/main/CODE_OF_CONDUCT.md).

--- a/docs/v1/03-documentation.md
+++ b/docs/v1/03-documentation.md
@@ -8,7 +8,7 @@ contains `TODO` placeholders. v1 must ship a complete, navigable set of docs.
 
 ### D1. Top-level `README.md` rewrite
 
-- [ ] Replace the body with:
+- [x] Replace the body with:
   - One-paragraph elevator pitch (matches `00-overview.md`).
   - Status badges (CI, Gem version, downloads, license, Ruby versions).
   - Install instructions (`bundle add assistant` and `gem install assistant`).
@@ -20,10 +20,15 @@ contains `TODO` placeholders. v1 must ship a complete, navigable set of docs.
   - Link to `docs/getting-started.md` and `docs/api-reference.md`.
   - "Roadmap" section linking to `docs/v1/README.md`.
   - Keep the existing License + Code of Conduct sections.
-- [ ] Remove every `TODO:` placeholder (`README.md:5`, `README.md:25`).
-- [ ] Replace `https://github.com/[USERNAME]/assistant` with
+- [x] Remove every `TODO:` placeholder (`README.md:5`, `README.md:25`).
+- [x] Replace `https://github.com/[USERNAME]/assistant` with
       `https://github.com/ramongr/assistant` (`README.md:35`,
       `README.md:43`).
+
+> Documentation index links point at `docs/v1/01-api-surface.md` and the
+> existing planning docs until D2/D3 land the user-facing
+> `docs/getting-started.md` and `docs/api-reference.md` siblings. The
+> README will be re-linked as part of the D2 PR.
 
 ### D2. New user-facing pages under `docs/` (siblings of `docs/v1/`)
 


### PR DESCRIPTION
## Scope

Closes the D1 deliverable from
[`docs/v1/03-documentation.md`](docs/v1/03-documentation.md) and the
README-related success criterion in
[`docs/v1/00-overview.md`](docs/v1/00-overview.md) ("`README.md` no longer
contains any `TODO:` from the bundler template").

The previous `README.md` was the 43-line `bundler gem` template: two
`TODO:` placeholders (lines 5 and 25) and `https://github.com/[USERNAME]/assistant`
URLs in Contributing / Code of Conduct. Embarrassing for rubygems.org and
github.com at 1.0.

## What this PR ships

- New `README.md`:
  - Elevator pitch matching `docs/v1/00-overview.md`.
  - Status badges: CI workflow, gem version, downloads, Ruby `>= 3.4`, MIT.
  - Install: `bundle add assistant` and `gem install assistant`.
  - **60-second runnable example** (`CreateUser` service) covering required
    inputs, defaults, `allow_nil:`, the `validate` hook, and the
    `log_item_warning` / `log_item_error` shorthands. Smoke-tested
    against HEAD before being pasted in.
  - Both canonical result-hash shapes (`:ok` / `:with_warnings` vs
    `:with_errors`) documented inline.
  - "Why another service-object gem?" comparison against
    Interactor and dry-transaction, plus the soft-fail / no-runtime-deps
    pitch.
  - Documentation index pointing at the planning docs we already ship
    (`01-api-surface`, `02-features`, the `0.x -> 1` migration guide,
    deprecations, `examples/greeter.rb`, `CHANGELOG.md`, the v1 roadmap
    `README`).
  - Development section listing `rake test`, `rubocop`, `steep check`,
    and `bin/console`.
  - Contributing / License / Code of Conduct sections kept; URLs now
    point at `ramongr/assistant` on the `main` branch (not `master` or
    `[USERNAME]`).

- `CHANGELOG.md` `[Unreleased] -> Added`: D1 entry.

- `docs/v1/03-documentation.md`: D1 checklist flipped to `[x]` with a
  one-paragraph note that the README documentation index will be
  re-pointed at `docs/getting-started.md` / `docs/api-reference.md` as
  part of the D2 PR (those user-facing guides do not exist yet).

## Sample

The 60-second `CreateUser` example from the README, executed against HEAD:

```text
$ bundle exec ruby -Ilib /tmp/d1_smoke.rb
{result: {id: 42, email: "ada@example.com", name: "Ada", age: nil}, status: :with_warnings, warnings: [#<Assistant::LogItem ... @level=:warning, @source=:execute, @detail=:age, @message="age missing", @trace=nil>]}
{errors: [#<Assistant::LogItem ... @level=:error, @source=:validate, @detail=:email, @message="must contain @", @trace=nil>], result: nil, status: :with_errors}
```

## Verification

\`\`\`text
\$ bundle exec rake test
223 runs, 599 assertions, 0 failures, 0 errors, 0 skips

\$ bundle exec rubocop
40 files inspected, no offenses detected

\$ bundle exec steep check --jobs=1
No type error detected. 🫖
\`\`\`

## Out of scope

- D2 user-facing guides (`docs/getting-started.md`, `docs/guides/*.md`,
  `docs/api-reference.md`) -- ship in a separate PR; the README index
  will then be re-pointed at them.
- D3 YARD doc comments on every Frozen symbol.
- D4 hygiene files (`CONTRIBUTING.md`, `SECURITY.md`,
  `.github/PULL_REQUEST_TEMPLATE.md`).
- D5 `examples/rails_service/` and `examples/cli_handler/` runnable
  scripts.
- Gemspec metadata / version bump / RC tag from
  `docs/v1/04-release-checklist.md`.