### PR TITLE
docs(v1): flip M1/M2/M3/M5/M13 status to shipped + tooling note

### DIFF
--- a/docs/v1/02-features.md
+++ b/docs/v1/02-features.md
@@ -186,7 +186,7 @@ even with `allow_nil: true`" interaction (point 8); it must be loudly
 documented to avoid surprise.
 
 - **Owner**: _TBD_.
-- **Status**: `[ ]`.
+- **Status**: `[x]` — shipped in PR #137 (`53b1678`).
 
 ### M2. `input(..., allow_nil:)`
 
@@ -204,7 +204,7 @@ documented to avoid surprise.
 - **Risk**: low–medium. Must not change behaviour when `allow_nil:` is
   omitted (back-compat).
 - **Owner**: _TBD_.
-- **Status**: `[ ]`.
+- **Status**: `[x]` — shipped in PR #136 (`38b2897`).
 
 ### M3. `input(..., type: [A, B])`
 
@@ -221,7 +221,7 @@ documented to avoid surprise.
 - **Risk**: low. The type-check call site is a single line in
   `lib/assistant/input_builder.rb:73`.
 - **Owner**: _TBD_.
-- **Status**: `[ ]`.
+- **Status**: `[x]` — shipped in PR #135 (`42bd89d`).
 
 ### M4. Public `Service#logs` reader
 
@@ -257,7 +257,7 @@ documented to avoid surprise.
   per level; assert the resulting `LogItem` is shaped correctly.
 - **Risk**: low. Pure additions on `LogList`.
 - **Owner**: _TBD_.
-- **Status**: `[ ]`.
+- **Status**: `[x]` — shipped in PR #134 (`a318a24`).
 
 #### Open follow-ups (out of scope for M5, tracked for 1.x)
 
@@ -632,7 +632,7 @@ documented to avoid surprise.
   whole module to just `accessors.rb`; existing checker tests cover
   the whitespace path.
 - **Owner**: _TBD_.
-- **Status**: `[ ]`.
+- **Status**: `[x]` — shipped in PR #143 (`01d82b1`).
 
 ---
 

--- a/docs/v1/05-quality-and-tooling.md
+++ b/docs/v1/05-quality-and-tooling.md
@@ -51,10 +51,12 @@ Configuration lives in `.rubocop.yml` and `.rubocop_todo.yml`.
       `Assistant::InputBuilder` and `Assistant::Refinements` are
       predeclared in `lib/assistant.rb` so multi-segment files load
       without ordering hazards.
-- [ ] Drop the temporary `Metrics/ModuleLength: Max: 150` override
+- [x] Drop the temporary `Metrics/ModuleLength: Max: 150` override
       (added for M7) once M13 ships and `lib/assistant/input_builder.rb`
       is split into per-concern submodules. See
-      [`02-features.md`](./02-features.md) M13.
+      [`02-features.md`](./02-features.md) M13. Removed alongside M13
+      (PR #143, `01d82b1`); `.rubocop.yml` now has no `Metrics/ModuleLength`
+      override.
 
 ## Brakeman + Fasterer
 


### PR DESCRIPTION
## Scope

Pure docs sweep against the v1 roadmap in [`docs/v1/02-features.md`](docs/v1/02-features.md)
and [`docs/v1/05-quality-and-tooling.md`](docs/v1/05-quality-and-tooling.md).
Five Must-list milestones already landed on `main` but their status lines
still read `[ ]` Planned, which gives a misleading picture of how much of
1.0 is left.

No library code, tests, RBS, gemspec, or CI changes.

## What this PR ships

`docs/v1/02-features.md` — flip the five stale entries to `[x]` with the
merge PR # and short SHA, matching the format already used for M4 and M6:

| Item | New status |
|---|---|
| M1 `input(..., default:)` | `[x]` — shipped in PR #137 (`53b1678`) |
| M2 `input(..., allow_nil:)` | `[x]` — shipped in PR #136 (`38b2897`) |
| M3 `input(..., type: [A, B])` | `[x]` — shipped in PR #135 (`42bd89d`) |
| M5 `log_item_*` shorthands on `LogList` | `[x]` — shipped in PR #134 (`a318a24`) |
| M13 split `Assistant::InputBuilder` | `[x]` — shipped in PR #143 (`01d82b1`) |

`docs/v1/05-quality-and-tooling.md` — flip the `Metrics/ModuleLength: Max: 150`
override checklist item to `[x]` and note that the override was removed
alongside M13 (PR #143 / `01d82b1`); `.rubocop.yml` currently carries no
`Metrics/ModuleLength` block.

## Effect on the roadmap snapshot

After this PR, every Must (M1–M13) and every promoted Should (M-S1..M-S4)
in `docs/v1/02-features.md` is marked shipped. The remaining open work for
1.0 sits in:

- `docs/v1/03-documentation.md` (Phase 4 docs: README rewrite, YARD, guides, examples)
- `docs/v1/04-release-checklist.md` (gemspec polish, dev deps, version bump, RC, release)
- `docs/v1/05-quality-and-tooling.md` (SimpleCov, Brakeman + Fasterer CI, `rake ci`, `.rubocop_todo.yml` empty-out)
- `docs/v1/08-github-pages.md` (parallel; not a 1.0 gate)

## Verification

```
$ bundle exec rake test
223 runs, 599 assertions, 0 failures, 0 errors, 0 skips

$ bundle exec rubocop
40 files inspected, no offenses detected

$ bundle exec steep check --jobs=1
No type error detected.
```

## Out of scope

- Updating `docs/v1/03-documentation.md` / `04-release-checklist.md` /
  `05-quality-and-tooling.md` work items themselves — those land per
  concern in their own PRs.
- Triaging the stale GH issues #52–#56 (2023-era attribute-block requests
  now subsumed by M1/M2/M3/M7) — handled as a separate gh-side cleanup,
  not part of this branch.