### PR TITLE
chore(ci): add SimpleCov with branch coverage and CI summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,45 @@ jobs:
           bundler-cache: true
       - name: Run Steep
         run: bundle exec steep check --jobs=1
+
+  coverage:
+    name: Coverage (SimpleCov)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '4.0'
+          bundler-cache: true
+      - name: Run tests with SimpleCov
+        run: bundle exec rake test
+      - name: Append coverage summary
+        if: always()
+        run: |
+          ruby -rjson -e '
+            path = "coverage/.last_run.json"
+            unless File.exist?(path)
+              warn "no coverage/.last_run.json produced"
+              exit 0
+            end
+            data = JSON.parse(File.read(path))
+            line = data.dig("result", "line")
+            branch = data.dig("result", "branch")
+            File.open(ENV.fetch("GITHUB_STEP_SUMMARY"), "a") do |f|
+              f.puts "## SimpleCov coverage"
+              f.puts
+              f.puts "| Metric | Coverage | Soft target |"
+              f.puts "| ------ | -------- | ----------- |"
+              f.puts "| Line   | #{line}% | >= 98% |"
+              f.puts "| Branch | #{branch}% | >= 95% |"
+              f.puts
+              f.puts "Reported only; not enforced in CI. See docs/v1/05-quality-and-tooling.md."
+            end
+          '
+      - name: Upload coverage HTML artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html
+          path: coverage/
+          if-no-files-found: warn

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,7 @@ GEM
     colorize (1.1.0)
     concurrent-ruby (1.3.6)
     csv (3.3.5)
+    docile (1.4.1)
     drb (2.2.3)
     ffi (1.17.4)
     ffi (1.17.4-arm64-darwin)
@@ -78,6 +79,12 @@ GEM
       rubocop (>= 1.72, < 2.0)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
     steep (2.0.0)
       concurrent-ruby (>= 1.1.10)
       csv (>= 3.0.9)
@@ -120,6 +127,7 @@ DEPENDENCIES
   rubocop-performance (~> 1.26)
   rubocop-rake (~> 0.7)
   rubocop-style-compact_nesting (~> 0.1)
+  simplecov (~> 0.22)
   steep (~> 2.0)
 
 CHECKSUMS
@@ -131,6 +139,7 @@ CHECKSUMS
   colorize (1.1.0) sha256=30b5237f0603f6662ab8d1fc2bd4a96142b806c6415d79e45ef5fdc6a0cfc837
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
+  docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   ffi (1.17.4) sha256=bcd1642e06f0d16fc9e09ac6d49c3a7298b9789bcb58127302f934e437d60acf
   ffi (1.17.4-arm64-darwin) sha256=19071aaf1419251b0a46852abf960e77330a3b334d13a4ab51d58b31a937001b
@@ -161,6 +170,9 @@ CHECKSUMS
   rubocop-style-compact_nesting (0.1.1) sha256=0d549176ce2e2e9ef9c0434f41b0aa4cbc885321a5747d2c675b8eafc64d311f
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
+  simplecov (0.22.0) sha256=fe2622c7834ff23b98066bb0a854284b2729a569ac659f82621fc22ef36213a5
+  simplecov-html (0.13.2) sha256=bd0b8e54e7c2d7685927e8d6286466359b6f16b18cb0df47b508e8d73c777246
+  simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
   steep (2.0.0) sha256=6eb0ecc09637bbb54f0a5f2cf63daea6d3208ccace64b4f1107d976333605c30
   strscan (3.1.8) sha256=aae2db611a225559f21ffbb71765c9a4e60fd262534a9ea84f4f11c7f32f679e
   terminal-table (4.0.0) sha256=f504793203f8251b2ea7c7068333053f0beeea26093ec9962e62ea79f94301d2

--- a/assistant.gemspec
+++ b/assistant.gemspec
@@ -46,5 +46,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-performance', '~> 1.26'
   spec.add_development_dependency 'rubocop-rake', '~> 0.7'
   spec.add_development_dependency 'rubocop-style-compact_nesting', '~> 0.1'
+  spec.add_development_dependency 'simplecov', '~> 0.22'
   spec.add_development_dependency 'steep', '~> 2.0'
 end

--- a/docs/v1/05-quality-and-tooling.md
+++ b/docs/v1/05-quality-and-tooling.md
@@ -15,9 +15,9 @@ Today the suite is Minitest under `test/` (per the 0.1.0 migration noted in
 
 ### Goals for 1.0
 
-- [ ] Add SimpleCov to the dev dependencies and require it from
+- [x] Add SimpleCov to the dev dependencies and require it from
       `test/test_helper.rb` before `require "assistant"`.
-- [ ] Configure SimpleCov:
+- [x] Configure SimpleCov:
   - Track lines and branches.
   - **Target** (soft gate; report only): line ≥98%, branch ≥95%. CI
     surfaces the numbers in the job summary but does **not** fail when
@@ -25,9 +25,9 @@ Today the suite is Minitest under `test/` (per the 0.1.0 migration noted in
     [`07-risks-and-open-questions.md`](./07-risks-and-open-questions.md)
     decision.
   - Output to `coverage/`; gitignore the directory.
-- [ ] Add a CI step that publishes the SimpleCov HTML as an artifact for
+- [x] Add a CI step that publishes the SimpleCov HTML as an artifact for
       easy inspection on PRs.
-- [ ] Add a CI step that prints line/branch percentages to the GitHub
+- [x] Add a CI step that prints line/branch percentages to the GitHub
       Actions job summary (`$GITHUB_STEP_SUMMARY`).
 - [ ] Add `test/docs/` for example-block tests required by
       [`03-documentation.md`](./03-documentation.md) D5 acceptance criteria.
@@ -134,9 +134,11 @@ Current matrix (`.github/workflows/ci.yml:21`): `['3.4', '4.0']`.
 - [ ] Keep `fail-fast: false` so a single Ruby's flake doesn't mask others.
 - [ ] Run RuboCop on the highest matrix entry only (current behaviour;
       `.github/workflows/ci.yml:38`).
-- [ ] Add a `coverage` job that runs the test suite once with SimpleCov and
+- [x] Add a `coverage` job that runs the test suite once with SimpleCov and
       uploads the artifact (soft gate).
-- [ ] Add a **required** `steep` job per the section above.
+- [x] Add a **required** `steep` job per the section above. Already
+      live in `.github/workflows/ci.yml`; required by branch protection
+      via the `Steep` check.
 
 ## Bundler / dependency hygiene
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,12 @@
 
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
+require 'simplecov'
+SimpleCov.start do
+  enable_coverage :branch
+  add_filter %r{^/test/}
+end
+
 require 'assistant'
 require 'minitest/autorun'
 require 'minitest/pride'


### PR DESCRIPTION
## Scope

Quality/Tooling slice from [`docs/v1/05-quality-and-tooling.md`](../blob/main/docs/v1/05-quality-and-tooling.md) — the SimpleCov + CI summary items (also flips the now-shipped CI matrix items for `coverage` and the `steep` required job).

Ticks the following checkboxes:

- *Goals for 1.0* → SimpleCov dev dep + require, configure (line + branch, soft gate, `coverage/`), CI HTML artifact, `$GITHUB_STEP_SUMMARY` percentages.
- *CI matrix* → `coverage` job, required `steep` job (already live).

Still open in that doc: `test/docs/` (D5), Brakeman/Fasterer CI steps, `rake ci` aggregate, `.rubocop_todo.yml` empty-out, `bin/` smoke, dep-empty CI assertion, RBS-by-class doc note — they ship as follow-up slices.

## What this PR ships

- `assistant.gemspec`: `simplecov ~> 0.22` as a dev dep (transitive: `docile`, `simplecov-html`, `simplecov_json_formatter`).
- `test/test_helper.rb`: requires SimpleCov **before** `require "assistant"`, enables branch coverage, filters the `test/` tree. Output lands in `coverage/` (already gitignored).
- `.github/workflows/ci.yml`: new `Coverage (SimpleCov)` job on Ruby `4.0` that runs the suite, parses `coverage/.last_run.json`, appends a line/branch table to `$GITHUB_STEP_SUMMARY`, and uploads `coverage/` as the `coverage-html` artifact via `actions/upload-artifact@v4`. **Soft gate** — the job does not fail when coverage drops; human review enforces.
- `docs/v1/05-quality-and-tooling.md`: flips the four SimpleCov checkboxes plus the two CI-matrix items.

## Sample output

Local baseline (`bundle exec rake test`):

\`\`\`
223 runs, 599 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for Unit Tests to /…/assistant/coverage.
Line Coverage: 99.55% (439 / 441)
Branch Coverage: 95.65% (88 / 92)
\`\`\`

`coverage/.last_run.json`:

\`\`\`json
{
  "result": {
    "line": 99.54,
    "branch": 95.65
  }
}
\`\`\`

The CI summary will render as:

> ## SimpleCov coverage
>
> | Metric | Coverage | Soft target |
> | ------ | -------- | ----------- |
> | Line   | 99.54%   | >= 98% |
> | Branch | 95.65%   | >= 95% |

Both soft targets already met without touching production code.

## Verification

\`\`\`
$ bundle exec rake test
…
223 runs, 599 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for Unit Tests to …/assistant/coverage.
Line Coverage: 99.55% (439 / 441)
Branch Coverage: 95.65% (88 / 92)

$ bundle exec rubocop
…
40 files inspected, no offenses detected

$ bundle exec steep check --jobs=1
# Type checking files:
...............................
No type error detected. 🫖
\`\`\`

## Out of scope

- Brakeman + Fasterer CI steps and a `rake ci` aggregate task (next quality-tooling slice).
- `test/docs/` example-block harness — depends on D5 (Phase 4 docs).
- `.rubocop_todo.yml` empty-out and `bin/` smoke checks — separate slices.
- Hard coverage gate. Decision in `07-risks-and-open-questions.md` remains: soft gate only; human review enforces target.