### PR TITLE
D4: add CONTRIBUTING.md, SECURITY.md, PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,39 @@
+<!-- markdownlint-disable MD013 -->
+## Scope
+
+<!--
+Which roadmap milestone or issue does this PR implement?
+Link the relevant `docs/v1/*.md` line or the GitHub issue.
+-->
+
+## What this PR ships
+
+<!--
+Bullet list of the public-facing changes.
+-->
+
+-
+
+## Verification
+
+<!--
+Paste the tail of the local pipeline (or just confirm rake ci is green).
+
+```sh
+bundle exec rake ci
+```
+-->
+
+## Out of scope
+
+<!--
+Anything that was deliberately left for a follow-up PR.
+-->
+
+## Checklist
+
+- [ ] `CHANGELOG.md` entry added under `[Unreleased]`.
+- [ ] Tests added or updated under `test/`.
+- [ ] Docs updated under `docs/` (and the relevant `docs/v1/*.md` checkbox
+      flipped if a roadmap item is closing).
+- [ ] `bundle exec rake ci` is green locally.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **D4**: shipped the repository-hygiene files called for in
+  [`docs/v1/03-documentation.md`](docs/v1/03-documentation.md). New
+  `CONTRIBUTING.md` documents the clone / `bin/setup` flow, the local
+  pipeline (`rake test`, `rubocop`, `steep check`, `rake ci`), branch
+  naming, commit-tag conventions, and PR template expectations. New
+  `SECURITY.md` declares 1.x as the supported line, 0.x as EOL on the
+  `1.0.0` release, gives `cerberus.ramon@gmail.com` as the private
+  report channel, and commits to a 7-day first-response /
+  30-day-fix-or-mitigation-plan SLA. New
+  `.github/PULL_REQUEST_TEMPLATE.md` enforces the
+  `Scope / What ships / Verification / Out of scope` body shape and the
+  `CHANGELOG entry / tests added / docs updated / rake ci is green`
+  checklist on every pull request.
 - **D1**: rewrote the top-level `README.md`. Replaced the bundler-template
   `TODO:` placeholders and `[USERNAME]/assistant` URLs with an elevator
   pitch, status badges (CI, gem version, downloads, Ruby version,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,114 @@
+<!-- markdownlint-disable MD013 -->
+# Contributing to `assistant`
+
+Thanks for taking the time to contribute. `assistant` is a small, dependency-free
+service-object gem and it intends to stay that way; please read this guide
+end-to-end before opening your first pull request.
+
+By participating you agree to abide by the project's
+[Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## Quick start
+
+```sh
+git clone https://github.com/ramongr/assistant.git
+cd assistant
+bin/setup            # bundle install + any future bootstrap steps
+bundle exec rake     # default task runs the test suite
+```
+
+If `bin/console` is more your speed, that boots an IRB session with the gem
+preloaded.
+
+## Local checks
+
+Before you push, run the full local pipeline. The CI pipeline mirrors these
+tools and rejects pull requests that do not match.
+
+```sh
+bundle exec rake test           # Minitest
+bundle exec rubocop             # style + lint
+bundle exec steep check         # RBS / type-check
+bundle exec rake ci             # convenience aggregate (test + rubocop + steep)
+```
+
+SimpleCov runs automatically as part of `rake test` and writes its report to
+`coverage/`. Coverage is reported in CI but is **not a hard gate**; the long-
+term targets (≥98% line, ≥95% branch) are documented in
+[`docs/v1/05-quality-and-tooling.md`](./docs/v1/05-quality-and-tooling.md).
+
+## Branch naming
+
+| Branch                       | Use it for                                                 |
+|------------------------------|------------------------------------------------------------|
+| `feature/m<n>-<slug>`        | A roadmap milestone from `docs/v1/02-features.md`.         |
+| `feature/m-s<n>-<slug>`      | A promoted "Should" item (M-S1, M-S2, …).                  |
+| `docs/<slug>`                | Documentation-only changes (D1–D5, status sweeps, guides). |
+| `chore/<slug>`               | Tooling / housekeeping with no roadmap milestone.          |
+| `fix/<slug>` or `bug/<slug>` | Bug fixes that are not part of a milestone.                |
+| `refactor/<slug>`            | Internal refactors with no behavior change.                |
+
+## Commit message style
+
+```
+<TAG>: <imperative summary, ≤72 chars>
+
+<wrapped body explaining the WHAT and the WHY (not the HOW).
+Reference roadmap milestones or issues by ID.>
+```
+
+`<TAG>` is one of:
+
+- `M<n>` — a roadmap milestone (e.g. `M11: bin/assistant-rbs per-class RBS
+  generator`). Look up the number in [`docs/v1/02-features.md`](./docs/v1/02-features.md).
+- `M-S<n>` — a promoted "Should" item.
+- `D<n>` — a documentation milestone from
+  [`docs/v1/03-documentation.md`](./docs/v1/03-documentation.md).
+- `chore:`, `docs:`, `refactor:`, `fix:` — when the change does not map to a
+  roadmap entry.
+
+Wrap the body at ~72 columns. Do **not** paste tool output or file lists;
+`git diff` already shows that.
+
+## Pull requests
+
+Open the PR against `main`. The PR description follows the template at
+[`.github/PULL_REQUEST_TEMPLATE.md`](./.github/PULL_REQUEST_TEMPLATE.md) and
+should always cover:
+
+- **Scope** — which milestone / issue this implements (link the roadmap line).
+- **What this PR ships** — bullet list of the public-facing changes.
+- **Verification** — paste the green tail of `rake test`, `rubocop`, and
+  `steep check` (or `rake ci`).
+- **Out of scope** — what was deliberately left for later.
+
+Each pull request must:
+
+- [ ] Add or update a `CHANGELOG.md` entry under `[Unreleased]`.
+- [ ] Add or update tests in `test/`.
+- [ ] Update docs in `docs/` and the relevant `docs/v1/*.md` checklist if a
+      roadmap item is closing.
+- [ ] Pass `bundle exec rake ci` locally.
+
+CI will run on every push; the `Steep`, `RuboCop`, `Minitest (Ruby 3.4)`, and
+`Minitest (Ruby 4.0)` checks are required by branch protection.
+
+## Reporting bugs
+
+Open an issue at <https://github.com/ramongr/assistant/issues>. Please include:
+
+- The version of `assistant` you are using.
+- Your Ruby version.
+- A minimal, runnable reproduction (ideally a service definition plus the
+  exact call that fails).
+- The full `result` hash or backtrace.
+
+For security-sensitive reports, follow [`SECURITY.md`](./SECURITY.md) instead
+of the public tracker.
+
+## Code of Conduct
+
+Everyone interacting in this project's codebases, issue trackers, chat rooms,
+and mailing lists is expected to follow the
+[Contributor Covenant Code of Conduct](./CODE_OF_CONDUCT.md). Reports go to
+`cerberus.ramon@gmail.com`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+<!-- markdownlint-disable MD013 -->
+# Security Policy
+
+`assistant` is a small Ruby gem with no runtime dependencies and a tiny
+surface area, but security reports are still very welcome.
+
+## Supported versions
+
+| Version | Status                                                          |
+|---------|-----------------------------------------------------------------|
+| 1.x     | **Supported.** Security fixes land on `main` and ship promptly. |
+| 0.x     | **End of life** on the `1.0.0` release. No further fixes.       |
+
+The supported branch will always be the current `1.x` release line. There is
+no intention to backport security fixes to `0.x` once `1.0.0` ships; users on
+`0.x` should upgrade. The migration guide lives at
+[`docs/v1/06-migration-0x-to-1.md`](./docs/v1/06-migration-0x-to-1.md).
+
+## Reporting a vulnerability
+
+**Do not open a public GitHub issue or pull request for a security report.**
+
+Email <cerberus.ramon@gmail.com> with:
+
+- A description of the issue.
+- The version of `assistant` (and Ruby) you reproduced it on.
+- A minimal proof-of-concept or runnable reproduction.
+- Any suggested mitigation, if you have one.
+
+If the report involves dependencies pulled in by a downstream Rails or Sinatra
+application, please mention that too — `assistant` itself has zero runtime
+dependencies, so the issue may need to be routed upstream.
+
+## Response SLA
+
+We aim for the following turnaround on a best-effort basis:
+
+- **First response:** within **7 days** of receiving the email.
+- **Fix or mitigation plan:** within **30 days** of triage, depending on
+  severity. Critical issues are fast-tracked.
+
+You will be kept in the loop on the timeline and credited in the
+`CHANGELOG.md` entry once the fix ships, unless you ask to remain anonymous.
+
+## Coordinated disclosure
+
+We follow a coordinated-disclosure model: the fix is released first, the
+CHANGELOG entry calls out the affected versions and the reporter, and any
+CVE / GHSA advisory is filed afterwards. Please do not publish details
+publicly until the fixed release is out.

--- a/docs/v1/03-documentation.md
+++ b/docs/v1/03-documentation.md
@@ -64,17 +64,22 @@ Each guide includes:
 
 ### D4. Repository hygiene files
 
-- [ ] `CONTRIBUTING.md`: how to clone, `bin/setup`, run `rake test` and
+- [x] `CONTRIBUTING.md`: how to clone, `bin/setup`, run `rake test` and
       `rake ci`, branch naming, commit style, PR template expectations,
       code of conduct link.
-- [ ] `SECURITY.md`: supported versions table (1.x supported; 0.x EOL on
-      1.0.0 release), how to report vulnerabilities (private email,
-      response SLA).
-- [ ] `.github/PULL_REQUEST_TEMPLATE.md`: checklist that includes
-      "CHANGELOG entry added", "tests added", "docs updated".
-- [ ] Confirm `CODE_OF_CONDUCT.md` contact email is current
-      (`CODE_OF_CONDUCT.md` exists, last reviewed 2026-05-07).
-- [ ] Confirm `README.md` and `CHANGELOG.md` link to the right repo URL.
+- [x] `SECURITY.md`: supported versions table (1.x supported; 0.x EOL on
+      1.0.0 release), how to report vulnerabilities (private email
+      `cerberus.ramon@gmail.com`, 7-day first response / 30-day fix SLA).
+- [x] `.github/PULL_REQUEST_TEMPLATE.md`: checklist that includes
+      "CHANGELOG entry added", "tests added", "docs updated", and
+      "`bundle exec rake ci` is green".
+- [x] Confirm `CODE_OF_CONDUCT.md` contact email is current — verified
+      `cerberus.ramon@gmail.com` at `CODE_OF_CONDUCT.md:58` matches the
+      gemspec contact (`assistant.gemspec:14`).
+- [x] Confirm `README.md` and `CHANGELOG.md` link to the right repo URL —
+      `README.md` uses `https://github.com/ramongr/assistant` throughout
+      (badges, contributing, CoC); `CHANGELOG.md` has no URL references
+      (Keep-a-Changelog header sections only).
 
 ### D5. Examples
 


### PR DESCRIPTION
## Scope

Closes the **D4 — Repository hygiene files** cluster in
[`docs/v1/03-documentation.md`](./docs/v1/03-documentation.md). This is the
last documentation milestone whose only blocker was content (D3 is YARD
tooling, D2 is new user-facing guides, D5 is the examples gallery and is
explicitly not a 1.0 gate per `docs/v1/00-overview.md`).

## What this PR ships

- **`CONTRIBUTING.md`** — clone / `bin/setup` flow, full local pipeline
  (`rake test`, `rubocop`, `steep check`, `rake ci`), branch-naming
  conventions, commit-tag conventions (`M<n>` / `M-S<n>` / `D<n>` /
  `chore:` / `docs:` / `refactor:` / `fix:`), PR-template expectations,
  bug-reporting instructions, and CoC link.
- **`SECURITY.md`** — supported-versions table (1.x supported; 0.x EOL on
  the `1.0.0` release), private report channel `cerberus.ramon@gmail.com`
  (matches `assistant.gemspec:14` and `CODE_OF_CONDUCT.md:58`),
  best-effort SLA of 7-day first response / 30-day fix-or-mitigation
  plan, coordinated-disclosure policy.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — formalises the
  `Scope / What ships / Verification / Out of scope` body shape and bakes
  the `CHANGELOG entry / tests added / docs updated / rake ci green`
  checklist into the GitHub UI.
- **`docs/v1/03-documentation.md`** — flips all five D4 checkboxes,
  including the two "confirm existing files" audits (CoC contact + repo
  URLs in README / CHANGELOG).
- **`CHANGELOG.md`** — new `[Unreleased] / Added / D4` entry.

## Verification

\`\`\`
$ bundle exec rake ci
223 runs, 599 assertions, 0 failures, 0 errors, 0 skips
Line Coverage: 99.55% (439 / 441)
Branch Coverage: 95.65% (88 / 92)
Running RuboCop...
40 files inspected, no offenses detected
bundle exec steep check --jobs=1
No type error detected. 🫖
\`\`\`

## Out of scope

- **D3** (YARD comments, `.yardopts`, `yard stats` 100% gate, `yard` dev
  dep) — separate PR.
- **D2** (user-facing guides under `docs/`) — separate PR; the
  CONTRIBUTING.md already cross-links to the upcoming
  `docs/getting-started.md` *where it exists in the current main*.
- **`bin/setup` / `bin/console` smoke + doc note** from
  `docs/v1/05-quality-and-tooling.md` — CONTRIBUTING.md now references
  `bin/setup` and `bin/console`, which unblocks the smoke item for a
  follow-up.
- **Gemspec polish** (summary, description, `documentation_uri`, etc.) —
  release-checklist work, separate PR.
- **CHANGELOG `[Unreleased]` consolidation into `[1.0.0]`** — release
  flow, not a docs concern.