### PR TITLE
chore: polish gemspec for 1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Release prep**: gemspec polished for the 1.0 cut. `spec.summary`
+  rewritten to match the README elevator pitch
+  (`Tiny, dependency-free soft-fail service objects for Ruby`),
+  `spec.description` expanded into a 3-sentence heredoc covering
+  soft-fail semantics, the uniform result shape, the RBS / Steep
+  posture, and the zero-runtime-deps guarantee. Added
+  `spec.metadata['documentation_uri']`
+  (`https://rubydoc.info/gems/assistant`) and
+  `spec.metadata['bug_tracker_uri']`
+  (`https://github.com/ramongr/assistant/issues`). The `spec.files`
+  glob now excludes `examples/`, `docs/v1/`, and `docs/v1.x/` from the
+  packaged gem so internal planning material and runnable samples no
+  longer ship to RubyGems (Q9 decision in
+  [`docs/v1/07-risks-and-open-questions.md`](docs/v1/07-risks-and-open-questions.md)).
+  No behaviour change; `Assistant::VERSION` is unchanged.
+
 ### Changed (Breaking)
 
 - **M12**: `LogList#merge_logs` and every internal

--- a/assistant.gemspec
+++ b/assistant.gemspec
@@ -13,22 +13,35 @@ Gem::Specification.new do |spec|
   spec.authors = ['Ramon Rodrigues']
   spec.email = ['cerberus.ramon@gmail.com']
 
-  spec.summary = 'Simple, soft fail enabled, composable services'
-  spec.description = 'Simple, composable services'
+  spec.summary = 'Tiny, dependency-free soft-fail service objects for Ruby'
+  spec.description = <<~DESC
+    Assistant is a tiny, dependency-free Ruby library for writing soft-fail,
+    composable service objects. A service declares its inputs, validates
+    them, runs its body, and returns a uniform result that always carries
+    either a value plus warnings or a list of errors — never raising for
+    expected failures. Ships with RBS signatures, a 1.0-frozen public API,
+    and zero runtime gem dependencies.
+  DESC
   spec.homepage = 'https://github.com/ramongr/assistant'
   spec.license = 'MIT'
   spec.required_ruby_version = '>= 3.4'
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
+  spec.metadata['bug_tracker_uri'] = 'https://github.com/ramongr/assistant/issues'
   spec.metadata['changelog_uri'] = 'https://github.com/ramongr/assistant/blob/main/CHANGELOG.md'
+  spec.metadata['documentation_uri'] = 'https://rubydoc.info/gems/assistant'
   spec.metadata['homepage_uri'] = 'https://github.com/ramongr/assistant'
   spec.metadata['rubygems_mfa_required'] = 'true'
   spec.metadata['source_code_uri'] = 'https://github.com/ramongr/assistant'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  # Internal planning docs (`docs/v1/`, `docs/v1.x/`) and runnable examples
+  # are excluded from the packaged gem (Q9 decision).
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+    `git ls-files -z`.split("\x0").reject do |f|
+      f.match(%r{^(test|spec|features|examples|docs/v1(\.x)?)/})
+    end
   end
 
   spec.bindir = 'exe'

--- a/docs/v1/04-release-checklist.md
+++ b/docs/v1/04-release-checklist.md
@@ -12,23 +12,23 @@
 
 ## Pre-release: `assistant.gemspec` updates
 
-- [ ] `spec.summary` — replace
-      `"Simple, soft fail enabled, composable services"` (`assistant.gemspec:16`)
-      with the same one-liner used in `README.md`'s elevator pitch.
-- [ ] `spec.description` — expand from the current
-      `"Simple, composable services"` (`assistant.gemspec:17`) to a 2–3
-      sentence description matching `00-overview.md`.
-- [ ] Add `spec.metadata['documentation_uri'] = 'https://rubydoc.info/gems/assistant'`.
-- [ ] Add `spec.metadata['bug_tracker_uri'] = 'https://github.com/ramongr/assistant/issues'`.
-- [ ] Confirm `spec.metadata['changelog_uri']` (`assistant.gemspec:23`) still
-      points at `CHANGELOG.md` after merge.
-- [ ] Confirm `spec.required_ruby_version = '>= 3.4'` matches the CI floor
-      (`assistant.gemspec:20`, `.github/workflows/ci.yml`).
-- [ ] Confirm `spec.metadata['rubygems_mfa_required']` stays `'true'`
-      (`assistant.gemspec:25`).
-- [ ] Confirm the `spec.files` glob (`assistant.gemspec:30`) excludes
-      `docs/v1/`, `docs/v1.x/`, and `examples/` from the packaged gem
-      (Q9 decision; we don't ship internal plans or examples):
+- [x] `spec.summary` — replaced the bundler-template line with
+      `Tiny, dependency-free soft-fail service objects for Ruby`
+      (`assistant.gemspec:16`), matching the README elevator pitch.
+- [x] `spec.description` — expanded into a 3-sentence heredoc
+      (`assistant.gemspec:17-24`) covering soft-fail semantics, the
+      uniform result shape, RBS/Steep posture, and the zero-runtime-deps
+      guarantee.
+- [x] Added `spec.metadata['documentation_uri'] = 'https://rubydoc.info/gems/assistant'`.
+- [x] Added `spec.metadata['bug_tracker_uri'] = 'https://github.com/ramongr/assistant/issues'`.
+- [x] Confirmed `spec.metadata['changelog_uri']` still points at
+      `CHANGELOG.md` on `main`.
+- [x] Confirmed `spec.required_ruby_version = '>= 3.4'` matches both the
+      gemspec, `.rubocop.yml`'s `TargetRubyVersion`, and the CI matrix
+      floor (`'3.4'`).
+- [x] Confirmed `spec.metadata['rubygems_mfa_required']` stays `'true'`.
+- [x] `spec.files` glob now excludes `docs/v1/`, `docs/v1.x/`, and
+      `examples/` from the packaged gem per the Q9 decision:
   ```ruby
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject do |f|
@@ -36,11 +36,18 @@
     end
   end
   ```
-- [ ] Confirm `bin/assistant-rbs` (M11) is included in `spec.executables`
-      and listed in `spec.files`.
-- [ ] Add `yard` (development dep) per [`03-documentation.md`](./03-documentation.md).
-- [ ] Add `simplecov` (development dep) per [`05-quality-and-tooling.md`](./05-quality-and-tooling.md).
-- [ ] Add `steep` (development dep) per [`05-quality-and-tooling.md`](./05-quality-and-tooling.md).
+  Verified locally with `Gem::Specification.load("assistant.gemspec").files`
+  — 0 entries match `^docs/v1/`, 0 match `^examples/`.
+- [x] Confirmed the M11 CLI is shipped: `spec.bindir = 'exe'` plus the
+      `spec.files.grep(%r{^exe/})` for `spec.executables` resolves to
+      `["assistant-rbs"]`, with `exe/assistant-rbs` included in
+      `spec.files`.
+- [x] Added `yard` (development dep) — shipped in D3 at
+      `assistant.gemspec:50` (`yard ~> 0.9`).
+- [x] Added `simplecov` (development dep) — shipped with the SimpleCov
+      slice at `assistant.gemspec:48` (`simplecov ~> 0.22`).
+- [x] `steep` (development dep) was already declared pre-1.0 at
+      `assistant.gemspec:49` (`steep ~> 2.0`).
 
 ## Pre-release: source updates
 


### PR DESCRIPTION
## Scope

Closes the entire `Pre-release: assistant.gemspec updates` block in
[`docs/v1/04-release-checklist.md`](docs/v1/04-release-checklist.md)
plus the three dev-dep items (yard, simplecov, steep) that already
shipped earlier but were still listed as open. No behaviour change;
`Assistant::VERSION` is unchanged so this PR is safe to merge well
ahead of the actual release tag.

## What ships

- **`spec.summary`** rewritten to match the README elevator pitch:
  `Tiny, dependency-free soft-fail service objects for Ruby`.
- **`spec.description`** expanded into a 3-sentence heredoc covering
  soft-fail semantics, the uniform result shape, RBS / Steep posture,
  and the zero-runtime-deps guarantee.
- **`spec.metadata['documentation_uri']`** added →
  `https://rubydoc.info/gems/assistant`.
- **`spec.metadata['bug_tracker_uri']`** added →
  `https://github.com/ramongr/assistant/issues`.
- **`spec.files` glob** now excludes `examples/`, `docs/v1/`, and
  `docs/v1.x/` per the Q9 decision in
  [`07-risks-and-open-questions.md`](docs/v1/07-risks-and-open-questions.md).
  Internal planning material and runnable samples no longer ship to
  RubyGems.
- **`docs/v1/04-release-checklist.md`** flips all 11 gemspec checkboxes
  and the three dev-dep items, with audit evidence inline.
- **`CHANGELOG.md`** gets a new `### Changed` entry under
  `[Unreleased]` describing the metadata refresh.

## Sample output

\`\`\`text
\$ ruby -e 'spec = Gem::Specification.load(\"assistant.gemspec\"); \
            puts spec.summary; \
            p spec.executables; \
            p spec.metadata.slice(\"documentation_uri\",\"bug_tracker_uri\"); \
            puts \"files=#{spec.files.size}\"; \
            puts \"docs/v1 leaked=#{spec.files.grep(%r{^docs/v1/}).size}\"; \
            puts \"examples leaked=#{spec.files.grep(%r{^examples/}).size}\"'
Tiny, dependency-free soft-fail service objects for Ruby
[\"assistant-rbs\"]
{\"documentation_uri\"=>\"https://rubydoc.info/gems/assistant\", \"bug_tracker_uri\"=>\"https://github.com/ramongr/assistant/issues\"}
files=70
docs/v1 leaked=0
examples leaked=0
\`\`\`

## Verification

\`\`\`text
\$ bundle exec rake ci
223 runs, 599 assertions, 0 failures, 0 errors, 0 skips
Line Coverage: 99.55% (439 / 441)
Branch Coverage: 95.65% (88 / 92)
40 files inspected, no offenses detected
No type error detected. 🫖
yard: 100.00% documented
\`\`\`

## Out of scope

- Version bump to \`1.0.0\` and CHANGELOG \`[1.0.0]\` consolidation ship in
  a dedicated release-prep PR so this one can merge anytime.
- D2 user-facing guides (\`docs/getting-started.md\`,
  \`docs/guides/*.md\`, \`docs/api-reference.md\`) ship in their own PRs.
- \`bin/setup\` / \`bin/console\` / \`bin/version\` smoke test ships in
  a dedicated quality PR.