### PR TITLE
chore(ci): add bin/ scripts smoke job + document in CONTRIBUTING

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,3 +114,27 @@ jobs:
               exit 1
             end
           '
+
+  bin-smoke:
+    name: bin/ scripts smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          # Intentionally no bundler-cache: bin/setup is the thing under
+          # test; we want it to drive the bundle install end-to-end on a
+          # cold checkout.
+      - name: bin/setup smoke (cold bundle install)
+        run: ./bin/setup
+      - name: Syntax check bin/ scripts
+        run: |
+          bash -n bin/setup
+          ruby -c bin/console
+          ruby -c bin/version
+      - name: bin/version --help smoke
+        run: bundle exec bin/version --help
+      - name: bin/console loads assistant
+        run: |
+          echo 'puts Assistant::VERSION; exit' | bundle exec bin/console

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **bin/ smoke**: new `bin-smoke` job in `.github/workflows/ci.yml`
+  exercises `bin/setup` against a cold bundle, syntax-checks the three
+  developer scripts (`bash -n bin/setup`, `ruby -c bin/{console,version}`),
+  runs `bin/version --help`, and pipes a short ruby snippet through
+  `bin/console` to confirm `Assistant::VERSION` resolves. Closes the
+  `bin/` smoke item in
+  [`docs/v1/05-quality-and-tooling.md`](docs/v1/05-quality-and-tooling.md).
+  [`CONTRIBUTING.md`](CONTRIBUTING.md) gains a `bin/ developer scripts`
+  section documenting each script's purpose and noting that none of the
+  three ship in the packaged gem (only `exe/assistant-rbs` does).
+
 ### Changed
 
 - **Release prep**: gemspec polished for the 1.0 cut. `spec.summary`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,23 @@ bundle exec rake     # default task runs the test suite
 If `bin/console` is more your speed, that boots an IRB session with the gem
 preloaded.
 
+## `bin/` developer scripts
+
+The three checked-in scripts under `bin/` are developer conveniences. They
+are smoke-tested on every CI run by the `bin/ scripts smoke` job, so they
+should always work on a fresh clone.
+
+| Script        | What it does                                                       | Usage                                          |
+|---------------|--------------------------------------------------------------------|------------------------------------------------|
+| `bin/setup`   | Bash wrapper that runs `bundle install` on a cold checkout.        | `./bin/setup`                                  |
+| `bin/console` | Boots IRB with `bundler/setup` + `require 'assistant'` preloaded.  | `bin/console`                                  |
+| `bin/version` | Bumps `Assistant::VERSION` in `lib/assistant/version.rb`.          | `bin/version --patch` &#124; `--minor` &#124; `--major` &#124; `--help` |
+
+These scripts are **not packaged with the gem** — they live under `bin/`,
+not `exe/`. The only executable that ships in the gem is
+`exe/assistant-rbs` (M11). See [`assistant.gemspec`](./assistant.gemspec)
+for the `spec.executables` derivation.
+
 ## Local checks
 
 Before you push, run the full local pipeline. The CI pipeline mirrors these

--- a/docs/v1/05-quality-and-tooling.md
+++ b/docs/v1/05-quality-and-tooling.md
@@ -193,9 +193,16 @@ Current matrix (`.github/workflows/ci.yml:21`): `['3.4', '4.0']`.
 
 ## `bin/` scripts
 
-- [ ] Smoke-test `bin/setup`, `bin/console`, `bin/version` on a clean
-      checkout. Document them in `CONTRIBUTING.md` (D4 in
-      [`03-documentation.md`](./03-documentation.md)).
+- [x] Smoke-test `bin/setup`, `bin/console`, `bin/version` on a clean
+      checkout. A dedicated `bin-smoke` job in
+      `.github/workflows/ci.yml` runs on Ruby 3.4, exercises
+      `bin/setup` end-to-end against a cold bundle, syntax-checks the
+      three scripts (`bash -n bin/setup`, `ruby -c bin/{console,version}`),
+      runs `bin/version --help`, and pipes
+      `puts Assistant::VERSION; exit` through `bin/console` to confirm
+      the gem loads. Each script is documented in
+      [`CONTRIBUTING.md`](../../CONTRIBUTING.md) (D4) under
+      `bin/ developer scripts`.
 
 ## Acceptance criteria
 


### PR DESCRIPTION
## Scope

Closes the `bin/` scripts smoke item in
[`docs/v1/05-quality-and-tooling.md`](docs/v1/05-quality-and-tooling.md).
The three developer-only scripts (`bin/setup`, `bin/console`,
`bin/version`) had no CI coverage and were documented only via the
single \"Quick start\" snippet in CONTRIBUTING.md.

## What ships

- **New `bin-smoke` CI job** in `.github/workflows/ci.yml`. Runs on
  Ruby 3.4 without `bundler-cache` so `bin/setup` itself drives the
  bundle install. Steps:
  - `./bin/setup` (cold bundle install)
  - `bash -n bin/setup` + `ruby -c bin/console` + `ruby -c bin/version`
    syntax checks
  - `bundle exec bin/version --help` exits 0
  - `echo 'puts Assistant::VERSION; exit' | bundle exec bin/console`
    confirms the gem loads inside IRB
- **`CONTRIBUTING.md`** gains a `bin/ developer scripts` section: a
  three-row table listing each script's purpose and usage, plus a note
  that none of the three ship in the packaged gem (only
  `exe/assistant-rbs` does).
- **`docs/v1/05-quality-and-tooling.md`** flips the `bin/` smoke
  checkbox to `[x]` with full audit evidence.
- **`CHANGELOG.md`** Added entry under `[Unreleased]`.

## Verification

\`\`\`text
\$ bundle exec rake ci
223 runs, 599 assertions, 0 failures, 0 errors, 0 skips
Line Coverage: 99.55% (439 / 441)
Branch Coverage: 95.65% (88 / 92)
40 files inspected, no offenses detected
No type error detected. 🫖
yard: 100.00% documented

\$ ruby -c bin/console && ruby -c bin/version
Syntax OK
Syntax OK

\$ bundle exec bin/version --help
                                        VERSION BUMP OPTIONS
--patch-version --patch         Bumps the patch version
--minor-version --minor         Bumps the minor version and sets the patch version to 0
--major-version --version       Bumps the major version sets all other values to 0

\$ echo 'puts Assistant::VERSION; exit' | bundle exec bin/console
...
0.1.0
\`\`\`

## Out of scope

- The \`bin/\` scripts themselves are unchanged; only CI coverage and
  docs are added.
- The bigger D2 docs slice (user-facing guides under \`docs/\`) ships in
  its own PR.
- Release-prep PR (version bump + CHANGELOG [1.0.0] consolidation +
  SECURITY.md 0.x EOL line) ships separately.