### PR TITLE
D2: add docs/getting-started.md and docs/api-reference.md

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -5,6 +5,8 @@
 --protected
 lib/**/*.rb
 -
+docs/getting-started.md
+docs/api-reference.md
 CHANGELOG.md
 CONTRIBUTING.md
 SECURITY.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **D2** (entry pages): shipped `docs/getting-started.md` and
+  `docs/api-reference.md`. `docs/getting-started.md` walks from
+  `gem install` to a working `CreateUser` service across three runs
+  (one `:ok`, one `:with_warnings`, one `:with_errors`) and links out
+  to the four follow-up guides. `docs/api-reference.md` is the
+  hand-written, curated reference for every Frozen symbol on
+  `Assistant`, `Assistant::Service`, `Assistant::LogItem`,
+  `Assistant::LogList`, the execute callbacks, `#call_service`,
+  the notifier, `#input_snapshot`, and the `assistant-rbs` CLI;
+  `docs/v1/01-api-surface.md` remains the source of truth for
+  stability labels. `README.md` documentation index and the
+  `.yardopts` extra-files list now include both new pages. The four
+  topic guides (`inputs.md`, `validation.md`, `logging-and-results.md`,
+  `composing-services.md`) ship in a follow-up D2 PR alongside
+  `test/docs/` example tests.
 - **D3**: every public Frozen symbol enumerated in
   [`docs/v1/01-api-surface.md`](docs/v1/01-api-surface.md) now carries
   YARD documentation (`@param`, `@return`, `@raise`, `@example` where

--- a/README.md
+++ b/README.md
@@ -90,8 +90,12 @@ a per-class generator (`bin/assistant-rbs`) out of the box.
 
 ## Documentation
 
-- **API reference** — [`docs/v1/01-api-surface.md`](docs/v1/01-api-surface.md)
-  enumerates every public symbol with its stability label.
+- **Getting started** — [`docs/getting-started.md`](docs/getting-started.md)
+  walks from `gem install` to a first working service.
+- **API reference** — [`docs/api-reference.md`](docs/api-reference.md)
+  is the hand-written, curated reference for every Frozen symbol; the
+  source of truth for stability labels stays in
+  [`docs/v1/01-api-surface.md`](docs/v1/01-api-surface.md).
 - **Feature catalogue and rationale** —
   [`docs/v1/02-features.md`](docs/v1/02-features.md).
 - **Upgrading from 0.x** —
@@ -100,10 +104,11 @@ a per-class generator (`bin/assistant-rbs`) out of the box.
 - **Runnable sample** — [`examples/greeter.rb`](examples/greeter.rb).
 - **Changelog** — [`CHANGELOG.md`](CHANGELOG.md).
 
-Longer user-facing guides (`docs/getting-started.md`,
-`docs/guides/*.md`) are tracked in
-[`docs/v1/03-documentation.md`](docs/v1/03-documentation.md) and land in
-follow-up PRs.
+The deeper guides (`docs/guides/inputs.md`,
+`docs/guides/validation.md`, `docs/guides/logging-and-results.md`,
+`docs/guides/composing-services.md`) are tracked in
+[`docs/v1/03-documentation.md`](docs/v1/03-documentation.md) and land
+in follow-up PRs.
 
 ## Roadmap
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,259 @@
+<!-- markdownlint-disable MD013 MD024 -->
+# API reference
+
+This is the hand-written, curated reference for every public symbol
+that ships in `assistant` 1.0.0. The source of truth for stability
+labels is
+[`docs/v1/01-api-surface.md`](./v1/01-api-surface.md); the table
+of contents here mirrors it.
+
+Anything not listed on this page is **internal** and may change
+without a major version bump.
+
+## Stability labels
+
+- **Frozen** — covered by semver from 1.0.0 onward. Breaking changes
+  require a 2.0.
+- **Experimental** — public but subject to change in a 1.x minor
+  with a deprecation cycle.
+
+## Table of contents
+
+- [`Assistant` module](#assistant-module)
+- [`Assistant::Service`](#assistantservice)
+  - [Class methods](#class-methods)
+  - [Instance methods](#instance-methods)
+  - [Generated per-input methods](#generated-per-input-methods)
+  - [Result shape](#result-shape)
+- [`Assistant::LogItem`](#assistantlogitem)
+- [`Assistant::LogList`](#assistantloglist)
+- [Execute callbacks](#execute-callbacks)
+- [Service composition](#service-composition)
+- [Instrumentation notifier](#instrumentation-notifier)
+- [Input snapshot](#input-snapshot)
+- [`assistant-rbs` CLI](#assistant-rbs-cli)
+- [Semver and deprecation policy](#semver-and-deprecation-policy)
+
+---
+
+## `Assistant` module
+
+| Symbol                          | Stability                | Description                                                                              |
+|---------------------------------|--------------------------|------------------------------------------------------------------------------------------|
+| `Assistant::VERSION`            | Frozen                   | Semver-compliant `String`. Defined in `lib/assistant/version.rb`.                        |
+| `Assistant.notifier`            | Frozen *(new in 1.0)*    | Reader for the instrumentation proc. Defaults to a no-op.                                |
+| `Assistant.notifier=(callable)` | Frozen *(new in 1.0)*    | Writer. Accepts any object responding to `#call(event, payload)`.                        |
+
+See [Instrumentation notifier](#instrumentation-notifier) below for the
+event catalogue.
+
+---
+
+## `Assistant::Service`
+
+Subclass `Assistant::Service` and override `#execute` (and optionally
+`#validate`). Every other method on the table below is provided for
+you.
+
+### Class methods
+
+| Signature                                                                       | Stability | Description                                                                                              |
+|---------------------------------------------------------------------------------|-----------|----------------------------------------------------------------------------------------------------------|
+| `Service.run(**inputs) -> Hash`                                                 | Frozen    | One-shot. Instantiates with `inputs`, calls `#run`, returns the result hash.                             |
+| `Service.input(name, type:, required: false, optional: nil, if: nil, default: nil, allow_nil: false)` | Frozen | Declarative input. `name` is a leading positional symbol; everything else is keyword. See [Inputs](./guides/inputs.md). |
+| `Service.inputs(names, type:, **options)`                                       | Frozen    | Bulk declaration. `names` is an `Array<Symbol>`. Options apply to every input.                           |
+| `Service.before_execute(&block)`                                                | Frozen    | Hook block runs after validation, before `#execute`. `instance_exec`'d on the service.                   |
+| `Service.after_execute(&block)`                                                 | Frozen    | Hook block runs after `#execute` returns; receives the result as the block argument.                     |
+| `Service.around_execute(&block)`                                                | Frozen    | Hook block is `instance_exec`'d with an inner block argument that yields to the next layer.              |
+| `Service.input_snapshot_class -> Class`                                         | Frozen *(new in 1.0)* | Memoised `Data.define(*declared_input_names)` class used by `#input_snapshot`.                |
+
+> **M12 keyword-only sweep.** Every other public DSL helper (e.g.
+> `merge_logs`, all `InputBuilder` internals) takes keyword arguments
+> only. The two exemptions above — `Service.input` and
+> `Service.inputs` — keep their leading positional `name` / `names`
+> because the class-body declaration reads better as
+> `input :email, type: String` than `input name: :email, type: String`.
+
+### Instance methods
+
+| Signature                                          | Stability             | Description                                                                                                                              |
+|----------------------------------------------------|-----------------------|------------------------------------------------------------------------------------------------------------------------------------------|
+| `#initialize(**inputs)`                            | Frozen                | Stores `inputs` after applying every `default:`. Does **not** run validation or `#execute`.                                              |
+| `#run -> Hash`                                     | Frozen                | Runs `#validate`, the `before_execute` chain, `#execute` wrapped in `around_execute`, then `after_execute`. Returns the result hash.     |
+| `#result -> Object`                                | Frozen                | Memoised return value of `#execute`. `nil` on failure.                                                                                   |
+| `#success? -> Boolean`                             | Frozen                | True when status is `:ok` or `:with_warnings`.                                                                                           |
+| `#failure? -> Boolean`                             | Frozen                | True when status is `:with_errors`.                                                                                                      |
+| `#status -> Symbol`                                | Frozen                | Exactly one of `:ok`, `:with_warnings`, `:with_errors`.                                                                                  |
+| `#logs -> Array<Assistant::LogItem>`               | Frozen *(new in 1.0)* | All accumulated log items, in the order they were added.                                                                                 |
+| `#infos / #warnings / #errors`                     | Frozen                | Filtered subsets of `#logs`, by level.                                                                                                   |
+| `#call_service(klass, **inputs) -> Service`        | Frozen *(new in 1.0)* | Runs another service, merges its logs into this one, returns the inner instance. Errors on the inner flip this service to `:with_errors`. |
+| `#input_snapshot -> Data`                          | Frozen *(new in 1.0)* | Frozen value object capturing the post-default, post-`allow_nil` inputs. See [Composing services](./guides/composing-services.md).         |
+| `#execute -> Object` (override)                    | Frozen                | Your subclass overrides this. Return value becomes `result:`.                                                                            |
+| `#validate -> void` (override)                     | Frozen                | Optional. Add log items here to short-circuit `#execute`.                                                                                |
+
+### Generated per-input methods
+
+For every `input :name, type: T` declaration, the following are
+generated as instance methods on the service:
+
+| Method                                  | When generated                          | Description                                                                                                |
+|-----------------------------------------|-----------------------------------------|------------------------------------------------------------------------------------------------------------|
+| `#name`                                 | Always                                  | Reader for the post-default value of the input.                                                            |
+| `#name?`                                | Always                                  | Present-and-truthy predicate. Whitespace-only strings are treated as missing.                              |
+| `#valid_type_name? -> Boolean`          | Always                                  | True when `name` matches the declared `type:` (or is one of an `Array` type).                              |
+| `#valid_required_name? -> Boolean`      | When `required: true`                   | True when `name` is present (uses `#name?`). **Canonical name in 1.0.**                                    |
+| `#valid_require_name? -> Boolean`       | When `required: true`                   | **Deprecated in 1.0**, removed in 2.0. Delegates to `#valid_required_name?` with a `Kernel.warn` per call site. |
+| `#valid_required_conditional_name? -> Boolean` | When `required: true` **and** `if:` is supplied | True when the `if:` predicate is truthy **and** `name` is present.                                        |
+| `#valid_require_conditional_name? -> Boolean`  | Same                                  | **Deprecated in 1.0**, removed in 2.0. Delegates with a warning.                                          |
+
+See [`docs/deprecations.md`](./deprecations.md) for the deprecation
+table and migration recipe.
+
+### Result shape
+
+`Service#run` (and therefore `Service.run`) always returns one of two
+hash shapes:
+
+```ruby
+# Success
+{ result: <Object>, status: :ok | :with_warnings, warnings: Array<LogItem> }
+
+# Failure
+{ result: nil, status: :with_errors, errors: Array<LogItem> }
+```
+
+The status enum is exhaustively `:ok`, `:with_warnings`, `:with_errors`.
+No new status values may be added in 1.x without a deprecation cycle.
+
+---
+
+## `Assistant::LogItem`
+
+> **Breaking change in 1.0 (M10).** `LogItem.new` now raises
+> `ArgumentError` when any required attribute is invalid. The
+> `#valid?` family is **retained** for introspection, but in normal
+> flows it always returns `true` after a successful `new`.
+
+| Signature                                                                                | Stability                |
+|------------------------------------------------------------------------------------------|--------------------------|
+| `LogItem.new(level:, source:, detail:, message:, trace: nil)`                            | Frozen *(raises in 1.0)* |
+| `#level / #source / #detail / #message / #trace` — readers                               | Frozen                   |
+| `#info? / #warning? / #error?` — level predicates                                        | Frozen                   |
+| `#valid? / #valid_level? / #valid_source? / #valid_detail? / #valid_message?`            | Frozen                   |
+| `#item -> Hash{Symbol => Object}`                                                        | Frozen                   |
+| `Assistant::LogItem::VALID_LEVELS` — `%i[info warning error]`                            | Frozen                   |
+
+`#level`, `#source`, `#detail` are always `Symbol`; `#message` is
+`String`; `#trace` is `String` or `nil`.
+
+---
+
+## `Assistant::LogList`
+
+Mixin module included in `Assistant::Service`. Users don't normally
+include it themselves; the methods are available on any service
+instance.
+
+| Signature                                                          | Stability                |
+|--------------------------------------------------------------------|--------------------------|
+| `#add_log(level:, source:, detail:, message:, trace: nil)`         | Frozen                   |
+| `#merge_logs(logs:)`                                               | Frozen *(keyword-only in 1.0)* |
+| `#log_item_error_initialize(attr_name:, message:)`                 | Frozen                   |
+| `#log_item_info(source:, detail:, message:, trace: nil)`           | Frozen *(new in 1.0)*    |
+| `#log_item_warning(source:, detail:, message:, trace: nil)`        | Frozen *(new in 1.0)*    |
+| `#log_item_error(source:, detail:, message:, trace: nil)`          | Frozen *(new in 1.0)*    |
+| `#infos / #warnings / #errors -> Array<LogItem>`                   | Frozen                   |
+
+See [Logging and results](./guides/logging-and-results.md) for the
+`log_item_*` shorthands vs. the explicit `add_log` form.
+
+---
+
+## Execute callbacks
+
+New in 1.0. Class-level DSL on `Assistant::Service`; see the table
+under [Class methods](#class-methods).
+
+Hook error semantics: an exception raised inside any `before_execute`,
+`after_execute`, or `around_execute` hook is caught and logged via
+`add_log(level: :error, source: :hook, ...)` — it **never** propagates
+out of `#run`. See [Composing services](./guides/composing-services.md).
+
+---
+
+## Service composition
+
+| Signature                                                  | Stability                |
+|------------------------------------------------------------|--------------------------|
+| `#call_service(klass, **inputs) -> Assistant::Service`     | Frozen *(new in 1.0)*    |
+
+Constructs `klass`, runs it, merges the inner instance's `#logs` into
+the caller's, and returns the inner instance for further inspection.
+If the inner service has any error-level log item, the outer service's
+status becomes `:with_errors`.
+
+---
+
+## Instrumentation notifier
+
+Configured via `Assistant.notifier = ->(event, payload) { ... }`.
+
+Events emitted in 1.0, each with a payload that always carries
+`:service_class` and `:duration_s`:
+
+- `:service_started`
+- `:service_validated`
+- `:service_executed`
+- `:service_failed`
+
+The event set is **Frozen** for 1.0. Adding events requires a minor
+release; removing one or removing a payload key requires a full
+deprecation cycle.
+
+---
+
+## Input snapshot
+
+| Signature                          | Stability                | Description                                                                                                  |
+|------------------------------------|--------------------------|--------------------------------------------------------------------------------------------------------------|
+| `#input_snapshot -> Data`          | Frozen *(new in 1.0)*    | Returns a frozen `Data.define(*declared_input_names).new(**post_default_inputs)`. Reflects post-`default:` / post-`allow_nil:` values. |
+
+The `Data` class is memoised on the service class — repeated calls
+return values whose `class` is `equal?`. See
+[Composing services](./guides/composing-services.md).
+
+---
+
+## `assistant-rbs` CLI
+
+Bundled executable shipped at `exe/assistant-rbs` (M11). Generates
+per-class RBS signatures for `Assistant::Service` subclasses so Steep
+can type-check user code.
+
+| Invocation                                                  | Stability     |
+|-------------------------------------------------------------|---------------|
+| `bundle exec assistant-rbs PATH [--output sig/]`            | Experimental  |
+
+Scans `PATH` for `Assistant::Service` subclasses and emits
+`sig/<class>.rbs` with `def name: () -> Type` and `def name?: () -> bool`
+per declared input. A multi-type `type:` produces a union; `allow_nil:`
+produces a nullable type. The output is idempotent — running twice
+overwrites the same file with the same contents.
+
+Labelled **Experimental** in 1.0 because the output format may evolve
+in 1.x as RBS support for richer types matures.
+
+---
+
+## Semver and deprecation policy
+
+- **Patch (1.0.x)**: bug fixes, doc updates, internal refactors with no
+  observable behaviour change.
+- **Minor (1.x.0)**: additive API only — new `input` options, new
+  `LogItem` predicates, new `Service` hooks. No removals.
+- **Major (2.0.0)**: removals, renames, behaviour changes that break
+  the contract above.
+
+Every deprecated symbol lives for **at least one further minor** after
+its deprecation, with a `Kernel.warn` runtime warning and a row in
+[`docs/deprecations.md`](./deprecations.md).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,131 @@
+<!-- markdownlint-disable MD013 MD024 -->
+# Getting started
+
+> **TL;DR** — Subclass `Assistant::Service`, declare your inputs with
+> `input`, write an `execute` body, and call `YourService.run(**args)`.
+> You always get a hash back: either
+> `{ result:, status: :ok | :with_warnings, warnings: [...] }` or
+> `{ result: nil, status: :with_errors, errors: [...] }`. The gem
+> never raises for expected failures.
+
+This page walks a brand-new user from `gem install` to a working
+service. For deeper topics, jump to the guides:
+
+- [Inputs](./guides/inputs.md) — every option on `input` and `inputs`.
+- [Validation](./guides/validation.md) — the `validate` hook and how
+  to log warnings vs. errors.
+- [Logging and results](./guides/logging-and-results.md) — `LogItem`,
+  the `log_item_*` shorthands, the result hash.
+- [Composing services](./guides/composing-services.md) — `call_service`,
+  callbacks, the instrumentation notifier, `#input_snapshot`.
+
+The API contract is enumerated in
+[`api-reference.md`](./api-reference.md).
+
+## Install
+
+With Bundler (recommended):
+
+```sh
+bundle add assistant
+```
+
+Without Bundler:
+
+```sh
+gem install assistant
+```
+
+Ruby `>= 3.4` is required. The gem has **zero runtime dependencies** —
+adding it never pulls in another gem.
+
+## Your first service
+
+Create a file `create_user.rb`:
+
+```ruby
+require 'assistant'
+
+class CreateUser < Assistant::Service
+  input :email, type: String,  required: true
+  input :name,  type: String,  required: true
+  input :age,   type: Integer, allow_nil: true, default: nil
+
+  def validate
+    return if email.include?('@')
+
+    log_item_error(source: :validate, detail: :email, message: 'must contain @')
+  end
+
+  def execute
+    log_item_warning(source: :execute, detail: :age, message: 'age missing') if age.nil?
+
+    { id: 42, email:, name:, age: }
+  end
+end
+```
+
+Run it:
+
+```ruby
+CreateUser.run(email: 'a@b.com', name: 'Alice')
+# => { result: { id: 42, email: "a@b.com", name: "Alice", age: nil },
+#      status: :with_warnings,
+#      warnings: [#<Assistant::LogItem level=:warning ...>] }
+
+CreateUser.run(email: 'oops', name: 'Bob', age: 30)
+# => { result: nil,
+#      status: :with_errors,
+#      errors: [#<Assistant::LogItem level=:error  ...>,
+#               #<Assistant::LogItem level=:error  ...>] }
+
+CreateUser.run(email: 'c@d.com', name: 'Carol', age: 30)
+# => { result: { id: 42, ... }, status: :ok, warnings: [] }
+```
+
+Three runs, three different statuses, **zero exceptions**.
+
+## Reading the result hash
+
+Every `Service.run` returns one of two shapes:
+
+```ruby
+# Success (status is :ok or :with_warnings)
+{ result: <Object>, status: :ok | :with_warnings, warnings: Array<LogItem> }
+
+# Failure
+{ result: nil, status: :with_errors, errors: Array<LogItem> }
+```
+
+Pattern-matching is the cleanest way to consume it:
+
+```ruby
+case CreateUser.run(email: 'a@b.com', name: 'Alice')
+in { result:, status: :ok }
+  render json: result
+in { result:, status: :with_warnings, warnings: }
+  WarningsLogger.log(warnings)
+  render json: result
+in { errors:, status: :with_errors }
+  render json: { errors: errors.map(&:item) }, status: :unprocessable_entity
+end
+```
+
+The `:status` value is exhaustively one of `:ok`, `:with_warnings`,
+`:with_errors`. No new status values can be introduced in 1.x without a
+deprecation cycle.
+
+## What's next
+
+- The same example, but with optional / multi-type inputs and a
+  `default:` lambda → [Inputs guide](./guides/inputs.md).
+- Logging structured warnings during `#execute`, conditional
+  validation, the strict `LogItem` constructor →
+  [Logging and results](./guides/logging-and-results.md) +
+  [Validation](./guides/validation.md).
+- Wrapping one service inside another with shared log merging →
+  [Composing services](./guides/composing-services.md).
+- Per-class RBS signatures for Steep users → run
+  `bundle exec assistant-rbs lib --output sig`. See the
+  [Inputs guide](./guides/inputs.md) for the limitation it works
+  around.

--- a/docs/v1/03-documentation.md
+++ b/docs/v1/03-documentation.md
@@ -32,15 +32,15 @@ contains `TODO` placeholders. v1 must ship a complete, navigable set of docs.
 
 ### D2. New user-facing pages under `docs/` (siblings of `docs/v1/`)
 
-| File                                  | Contents                                                                  |
-|---------------------------------------|---------------------------------------------------------------------------|
-| `docs/getting-started.md`             | Install, first service, running it, reading the result hash, status enum. |
-| `docs/guides/inputs.md`               | `input` / `inputs`, type checks, `required:`, `optional:`, `if:`, `default:`, `allow_nil:`, multi-type; "Using `bin/assistant-rbs`" subsection (M11) explaining the per-class RBS generator and R1's metaprogramming limitation. |
-| `docs/guides/validation.md`           | `validate` hook, when to log warnings vs errors, conditional requirements. Note that `LogItem.new` is now strict (M10). |
-| `docs/guides/logging-and-results.md`  | `LogItem` shape and **strict construction** (M10), levels, `add_log`, `merge_logs`, the `log_item_info/warning/error` shorthands (M5), `#logs` / `#warnings` / `#errors`, result hash. |
-| `docs/guides/composing-services.md`   | Manual composition today; `call_service` (M-S2); error/warning propagation rules; using callbacks (M-S1) and the instrumentation notifier (M-S3); reading `#input_snapshot` (M-S4). |
-| `docs/api-reference.md`               | Curated, hand-written reference of every Frozen symbol from `01-api-surface.md`. Auto-generation deferred. |
-| `docs/deprecations.md`                | Created as part of M9; first entry documents the `valid_require_*?` → `valid_required_*?` deprecation. |
+| File                                  | Status | Contents                                                                  |
+|---------------------------------------|--------|---------------------------------------------------------------------------|
+| `docs/getting-started.md`             | [x] shipped | Install, first service, running it, reading the result hash, status enum. |
+| `docs/guides/inputs.md`               | [ ] follow-up PR | `input` / `inputs`, type checks, `required:`, `optional:`, `if:`, `default:`, `allow_nil:`, multi-type; "Using `bin/assistant-rbs`" subsection (M11) explaining the per-class RBS generator and R1's metaprogramming limitation. |
+| `docs/guides/validation.md`           | [ ] follow-up PR | `validate` hook, when to log warnings vs errors, conditional requirements. Note that `LogItem.new` is now strict (M10). |
+| `docs/guides/logging-and-results.md`  | [ ] follow-up PR | `LogItem` shape and **strict construction** (M10), levels, `add_log`, `merge_logs`, the `log_item_info/warning/error` shorthands (M5), `#logs` / `#warnings` / `#errors`, result hash. |
+| `docs/guides/composing-services.md`   | [ ] follow-up PR | Manual composition today; `call_service` (M-S2); error/warning propagation rules; using callbacks (M-S1) and the instrumentation notifier (M-S3); reading `#input_snapshot` (M-S4). |
+| `docs/api-reference.md`               | [x] shipped | Curated, hand-written reference of every Frozen symbol from `01-api-surface.md`. Auto-generation deferred. |
+| `docs/deprecations.md`                | [x] shipped (M9) | Created as part of M9; first entry documents the `valid_require_*?` → `valid_required_*?` deprecation. |
 
 Each guide includes:
 


### PR DESCRIPTION
## Scope

Closes two of the six rows in the D2 deliverable from
[`docs/v1/03-documentation.md`](docs/v1/03-documentation.md#d2-new-user-facing-pages-under-docs-siblings-of-docsv1).
The remaining four rows (`docs/guides/*.md` + `test/docs/` example
tests) ship in a follow-up D2 PR.

## What this PR ships

- `docs/getting-started.md` — install instructions, a 60-second
  `CreateUser` walkthrough that exercises `required:`, `default:`,
  `allow_nil:`, `validate`, and the `log_item_*` shorthands, three
  runs that produce all three status values, and a pattern-match
  consumption snippet. Forward-links to the four pending topic
  guides and the API reference.
- `docs/api-reference.md` — hand-written, curated reference for every
  Frozen symbol in 1.0. Covers `Assistant` module, `Service` class +
  instance methods (with the M12 keyword-only exemption note for the
  `Service.input` / `Service.inputs` DSL), generated per-input
  methods including the deprecated `valid_require_*` family,
  result shape, `LogItem` with the M10 strict-construction note,
  `LogList` with keyword-only `merge_logs`, execute callbacks,
  `#call_service`, the four notifier events,
  `#input_snapshot`, and the `assistant-rbs` Experimental CLI.
  `docs/v1/01-api-surface.md` stays the source of truth for canonical
  stability labels.
- `README.md` documentation index updated to point at both new pages
  and to list the four pending guides.
- `.yardopts` extra-files list extended to include both new pages.
- `docs/v1/03-documentation.md` D2 table now shows per-row status
  (two shipped, four follow-up, two pre-existing).
- `CHANGELOG.md` gains a D2 entry under `[Unreleased]` → `### Added`.

## Verification

\`\`\`text
\$ bundle exec rake ci
223 runs, 599 assertions, 0 failures, 0 errors, 0 skips
Line Coverage: 99.55% (439 / 441)
Branch Coverage: 95.65% (88 / 92)
40 files inspected, no offenses detected
No type error detected. 🫖
yard: 100.00% documented
\`\`\`

## Out of scope

- D2 follow-up: `docs/guides/inputs.md`, `validation.md`,
  `logging-and-results.md`, `composing-services.md`, plus the
  `test/docs/` example-block tests called for in the D2 acceptance
  criteria. Shipping next.
- D5 (examples gallery) is not a 1.0 gate per
  [`00-overview.md`](docs/v1/00-overview.md).
- Release plumbing (version bump, CHANGELOG `[1.0.0]` consolidation,
  RC and tag) ships after the D2 follow-up.