### PR TITLE
D2: add docs/guides/ + test/docs/ for each user-facing guide

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -7,6 +7,10 @@ lib/**/*.rb
 -
 docs/getting-started.md
 docs/api-reference.md
+docs/guides/inputs.md
+docs/guides/validation.md
+docs/guides/logging-and-results.md
+docs/guides/composing-services.md
 CHANGELOG.md
 CONTRIBUTING.md
 SECURITY.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **D2 (follow-up)**: four user-facing guides under `docs/guides/` —
+  [`inputs.md`](docs/guides/inputs.md),
+  [`validation.md`](docs/guides/validation.md),
+  [`logging-and-results.md`](docs/guides/logging-and-results.md),
+  [`composing-services.md`](docs/guides/composing-services.md).
+  Each guide is mirrored by a `test/docs/<guide>_examples_test.rb`
+  integration test so the runnable examples can't silently drift from
+  the actual behaviour. `inputs.md` includes the "Using
+  `bin/assistant-rbs` for Steep users" subsection that closes the R1
+  user-facing-note item in
+  [`docs/v1/05-quality-and-tooling.md`](docs/v1/05-quality-and-tooling.md).
+  `.yardopts` extra-files list extended to include the four new pages
+  so they ship with the rendered YARD output.
+
 - **bin/ smoke**: new `bin-smoke` job in `.github/workflows/ci.yml`
   exercises `bin/setup` against a cold bundle, syntax-checks the three
   developer scripts (`bash -n bin/setup`, `ruby -c bin/{console,version}`),

--- a/docs/guides/composing-services.md
+++ b/docs/guides/composing-services.md
@@ -1,0 +1,216 @@
+<!-- markdownlint-disable MD013 MD024 -->
+# Composing services
+
+> **TL;DR** — Use `call_service(OtherService, **inputs)` to nest one
+> service inside another's `#execute`; logs from the inner service
+> are merged into the outer timeline automatically. Use
+> `before_execute` / `after_execute` / `around_execute` to share
+> cross-cutting concerns at the class level. Register
+> `Assistant.notifier =` once to instrument every service. Use
+> `#input_snapshot` to forward a read-only view of the inputs to a
+> collaborator.
+
+This guide covers the four composition surfaces shipped in 1.0:
+service-to-service calls (M-S2), execute callbacks (M-S1), the
+instrumentation notifier (M-S3), and the input snapshot (M-S4).
+
+## `#call_service`: nest one service inside another
+
+`call_service(klass, **inputs)` instantiates `klass`, runs it, merges
+its `#logs` into the outer service's timeline, and returns the inner
+service instance. It does **not** raise on inner failure — the
+outer `#execute` decides what to do based on `inner.success?` /
+`inner.failure?` / `inner.result`.
+
+```ruby
+class CreateUser < Assistant::Service
+  input :email, type: String, required: true
+  def execute = { id: 1, email: }
+end
+
+class SignUp < Assistant::Service
+  input :email, type: String, required: true
+
+  def execute
+    user = call_service(CreateUser, email:)
+    return if user.failure? # inner errors already on the outer timeline
+
+    { user: user.result, signed_up_at: Time.now }
+  end
+end
+
+result = SignUp.run(email: 'a@b.com')
+result.fetch(:status)              # => :ok
+result.fetch(:result)[:user][:id]  # => 1
+```
+
+Notes:
+
+- `klass` must be a subclass of `Assistant::Service`. Anything else
+  raises `ArgumentError`.
+- The inner service's `#logs` are appended to the outer service's
+  timeline via `merge_logs(logs: inner.logs)`. Because the outer
+  service's `errors` / `warnings` / `status` are derived from its
+  full `@logs`, inner errors **automatically** downgrade the outer
+  terminal status to `:with_errors`, and inner warnings surface as
+  `:with_warnings` — no special handling required.
+- `call_service` does **not** rescue exceptions raised by the inner
+  service's `#execute` (or by the configured `Assistant.notifier`).
+  Wrap in `begin/rescue` and record via `add_log(level: :error, ...)`
+  if the inner service may raise.
+- `call_service` always calls `inner.run`, so calling it twice would
+  re-execute the inner service.
+
+## Execute callbacks (M-S1)
+
+Three class-level DSL methods register callbacks around `#execute`.
+Hooks are evaluated in the context of the service instance.
+
+```ruby
+class CreateUser < Assistant::Service
+  input :email, type: String, required: true
+
+  before_execute do
+    log_item_info(source: :hook, detail: :before, message: "starting #{email}")
+  end
+
+  around_execute do |&blk|
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    value = blk.call
+    log_item_info(source: :hook, detail: :around,
+                  message: "took #{Process.clock_gettime(Process::CLOCK_MONOTONIC) - started}s")
+    value
+  end
+
+  after_execute do |result|
+    log_item_info(source: :hook, detail: :after, message: "result=#{result.inspect}")
+  end
+
+  def execute = { id: 1, email: }
+end
+```
+
+Behavior:
+
+- **Order:** `before_execute` hooks run in declaration order; then
+  `around_execute` hooks wrap the chain with the **first-declared**
+  hook as the outermost layer; finally `after_execute` hooks run
+  with the execute result as the single positional argument.
+- **Inheritance:** subclasses inherit a `dup` of each parent's hook
+  arrays. Adding hooks in a subclass does not affect the parent.
+- **Exceptions:** a `StandardError` raised inside any hook is logged
+  with `level: :error, source: :hook, detail: <hook_type>` and the
+  remaining hooks still fire. An `around_execute` hook that raises
+  before yielding to its continuation produces `nil` for that layer
+  and outer hooks still wrap normally.
+- **Missing block:** registering a hook without a block raises
+  `ArgumentError` at class-definition time.
+
+## Instrumentation notifier (M-S3)
+
+Assign a callable to `Assistant.notifier =` to receive a fixed set
+of events for **every** service execution:
+
+```ruby
+Assistant.notifier = lambda do |event, payload|
+  StatsD.increment("assistant.#{event}",
+                   tags: ["service:#{payload[:service_class]}"])
+  StatsD.timing("assistant.duration_s.#{event}",
+                payload[:duration_s] * 1000.0,
+                tags: ["service:#{payload[:service_class]}"])
+end
+```
+
+Events (frozen for 1.0):
+
+| Event                | When                                            |
+|----------------------|-------------------------------------------------|
+| `:service_started`   | Top of `#run`, before any validation.           |
+| `:service_validated` | After declarative + `#validate` checks pass.    |
+| `:service_executed`  | Success path — after `#execute` returns.        |
+| `:service_failed`    | Failure path — `#execute` was skipped.          |
+
+Payload always includes:
+
+- `:service_class` — the `Service` subclass.
+- `:duration_s` — Float seconds since the start of `#run`
+  (`Process::CLOCK_MONOTONIC`).
+
+The notifier is treated as untrusted infrastructure: any
+`StandardError` it raises is rescued and warned (`Kernel.warn`),
+so a misconfigured notifier cannot tear down every service in the
+process. `SystemExit` / `Interrupt` propagate.
+
+To disable instrumentation entirely, restore the default no-op:
+
+```ruby
+Assistant.notifier = Assistant::DEFAULT_NOTIFIER
+```
+
+## `#input_snapshot` (M-S4)
+
+`#input_snapshot` returns a read-only `Data` view of the service's
+declared inputs (post-`default:` / post-`allow_nil:`). It's the
+canonical way to hand a value object to a collaborator without
+exposing the full service instance:
+
+```ruby
+class CreateUser < Assistant::Service
+  input :email, type: String, required: true
+  input :role,  type: Symbol, default: :member
+
+  def execute
+    Mailer.welcome(input_snapshot)
+    { id: 1, **input_snapshot.to_h }
+  end
+end
+
+snapshot = CreateUser.new(email: 'a@b.com').tap(&:run).input_snapshot
+snapshot.email # => "a@b.com"
+snapshot.role  # => :member
+snapshot.to_h  # => { email: "a@b.com", role: :member }
+
+snapshot.email = 'x' # => NoMethodError (Data is structurally immutable)
+```
+
+Notes:
+
+- Members are exactly the keys of `input_definitions` — extra keyword
+  arguments to `#initialize` that have no `input` declaration are
+  excluded so the snapshot mirrors the public DSL.
+- A declared input with no default and no caller-supplied value
+  appears with `nil`, mirroring the per-input getter.
+- The snapshot class is memoized at the class level via
+  `Service.input_snapshot_class`, so repeated calls are cheap.
+- `Data` is structurally immutable. Mutable member values (an
+  `Array` passed as an input, say) keep their normal mutability —
+  the snapshot does not deep-freeze.
+
+## Common pitfalls
+
+- **Forgetting that `call_service` doesn't fail the outer service.**
+  If the inner failure should also fail the outer, check
+  `inner.failure?` (or `inner.errors.any?`) and call
+  `log_item_error(...)` in your `#execute`.
+- **Re-running `inner` after `call_service`.** `inner.run` was
+  already called; calling it again will re-execute and double-log.
+- **Mutating `#input_snapshot` member values.** They share identity
+  with the underlying inputs. Treat the snapshot as a view, not a
+  defensive copy.
+- **Putting validation in `before_execute`.** Use `#validate` — it
+  short-circuits `#execute` on errors. Hooks log but don't change
+  flow.
+- **Raising from a notifier.** It's swallowed (with a `warn`).
+  Non-`StandardError` exceptions still propagate, so don't use
+  `Kernel#exit`.
+
+## See also
+
+- [Inputs guide](./inputs.md) — `Service.input` / `Service.inputs`
+  and `#input_snapshot`.
+- [Validation guide](./validation.md) — `#validate`, conditional
+  requirements.
+- [Logging and results](./logging-and-results.md) — what
+  `merge_logs(logs:)` does, the result hash shape.
+- [API reference](../api-reference.md#assistantservice) for the
+  full callback / call_service / notifier surfaces.

--- a/docs/guides/inputs.md
+++ b/docs/guides/inputs.md
@@ -1,0 +1,327 @@
+<!-- markdownlint-disable MD013 MD024 -->
+# Inputs
+
+> **TL;DR** — Declare every input with `input :name, type: Type` at the
+> top of your service class. Inputs are positional in the DSL but the
+> service is constructed with keyword arguments. Use `required:`,
+> `optional:`, `default:`, `allow_nil:`, `if:`, and array types
+> (`type: [String, Symbol]`) to describe the shape exactly. `Steep`
+> users get per-class RBS signatures via `bundle exec assistant-rbs`.
+
+This guide covers every option you can pass to `input` (and the bulk
+`inputs` helper). See [`api-reference.md`](../api-reference.md#class-methods)
+for the canonical signatures and stability labels.
+
+## The DSL at a glance
+
+```ruby
+class CreateUser < Assistant::Service
+  input  :email,    type: String,  required: true
+  input  :name,     type: String,  required: true
+  input  :age,      type: Integer, allow_nil: true, default: nil
+  input  :role,     type: Symbol,  default: :member
+  inputs %i[street city], type: String, optional: true
+
+  def execute
+    # email, name, age, role, street, city are all readers here
+    { email:, name:, age:, role:, street:, city: }
+  end
+end
+```
+
+Three things to notice:
+
+1. **`input` and `inputs` take a leading positional name** (`:email`,
+   `%i[street city]`). Every other DSL option is a keyword argument.
+   This is the only place in the gem where a positional argument
+   survives the M12 keyword-only sweep — see
+   [`api-reference.md`](../api-reference.md#class-methods).
+2. **The constructor is keyword-only.** You call
+   `CreateUser.run(email: 'a@b.com', name: 'Alice')`, never
+   `CreateUser.run('a@b.com', 'Alice')`.
+3. **Per-input methods are generated for you.** For every `input :name`
+   you get `#name`, `#name?`, `#valid_type_name?`, and (when
+   `required: true`) `#valid_required_name?`. See
+   [`api-reference.md`](../api-reference.md#generated-per-input-methods).
+
+## `type:` — the only required option
+
+Every input must declare a `type:`. The most common values are plain
+classes:
+
+```ruby
+input :email, type: String
+input :age,   type: Integer
+input :tags,  type: Array
+```
+
+A `type:` mismatch logs an error and short-circuits `#execute`:
+
+```ruby
+class TouchEmail < Assistant::Service
+  input :email, type: String
+
+  def execute
+    email.upcase
+  end
+end
+
+TouchEmail.run(email: 42)
+# => { result: nil, status: :with_errors,
+#      errors: [#<LogItem detail: :email,
+#                       message: "Service argument with name email is not a String but Integer">] }
+```
+
+### Multi-type inputs (M3)
+
+Pass an array of classes when more than one is acceptable:
+
+```ruby
+class TouchIdentifier < Assistant::Service
+  input :id, type: [String, Integer]
+
+  def execute
+    id.to_s
+  end
+end
+
+TouchIdentifier.run(id: 'abc').fetch(:result) # => "abc"
+TouchIdentifier.run(id: 42).fetch(:result)    # => "42"
+TouchIdentifier.run(id: :nope).fetch(:status) # => :with_errors
+```
+
+The error message lists every accepted type.
+
+## `required: true`
+
+Mark an input required and the gem generates a
+`#valid_required_<name>?` validator. Missing or whitespace-only string
+values log an error:
+
+```ruby
+class CreateUser < Assistant::Service
+  input :email, type: String, required: true
+
+  def execute
+    { email: }
+  end
+end
+
+CreateUser.run(email: '')
+# => { result: nil, status: :with_errors,
+#      errors: [#<LogItem detail: :email,
+#                       message: "Service is missing argument with name email">] }
+
+CreateUser.run(email: 'a@b.com')
+# => { result: { email: "a@b.com" }, status: :ok, warnings: [] }
+```
+
+The deprecated 0.x name `#valid_require_<name>?` still works in 1.x —
+calls emit a one-time `Kernel.warn` per call site and delegate to the
+canonical predicate. See [`docs/deprecations.md`](../deprecations.md).
+
+## `default:` (M1)
+
+Provide a fallback when the caller omits an input. Pass a callable
+(method, lambda, or proc) to compute the default lazily — `assistant`
+warns if you pass a mutable literal like `[]` or `{}` that would be
+shared across calls.
+
+```ruby
+class TouchRole < Assistant::Service
+  input :role, type: Symbol, default: :member
+
+  def execute
+    role
+  end
+end
+
+TouchRole.run.fetch(:result)             # => :member
+TouchRole.run(role: :admin).fetch(:result) # => :admin
+```
+
+Lazy defaults are invoked with no arguments:
+
+```ruby
+input :token, type: String, default: -> { SecureRandom.uuid }
+```
+
+A `default:` provider that takes arguments raises `ArgumentError` at
+class-definition time.
+
+## `allow_nil:` (M2)
+
+By default, `nil` for a typed input logs a type-mismatch error.
+`allow_nil: true` makes `nil` a legal value:
+
+```ruby
+class TouchAge < Assistant::Service
+  input :age, type: Integer, allow_nil: true, default: nil
+
+  def execute
+    age
+  end
+end
+
+TouchAge.run.fetch(:result)            # => nil
+TouchAge.run(age: nil).fetch(:result)  # => nil
+TouchAge.run(age: 30).fetch(:result)   # => 30
+```
+
+Combine with `default:` to express "optional integer that defaults to
+nil and may be set to nil explicitly".
+
+## `optional: true` (M7)
+
+`optional: true` is a shorthand for "skip the presence check entirely;
+do not generate `#valid_required_name?`". It is mutually exclusive
+with `required: true`:
+
+```ruby
+class TouchNickname < Assistant::Service
+  input :nickname, type: String, optional: true
+
+  def execute
+    nickname.to_s.upcase
+  end
+end
+
+TouchNickname.run.fetch(:result)                 # => ""
+TouchNickname.run(nickname: 'ada').fetch(:result) # => "ADA"
+```
+
+If you actually want a typed-but-nullable value, prefer
+`allow_nil: true` plus `default: nil`; reserve `optional: true` for
+inputs whose absence simply means "don't bother".
+
+## `if:` — conditional requirement
+
+`if:` combined with `required: true` makes the presence check fire
+only when the predicate returns truthy. The predicate is called with
+the input's current value:
+
+```ruby
+class CreateUser < Assistant::Service
+  input :role,  type: Symbol, default: :member
+  input :email, type: String, required: true, if: ->(_value) { caller_wants_email? }
+
+  def execute
+    { email:, role: }
+  end
+
+  private
+
+  def caller_wants_email?
+    role == :admin
+  end
+end
+```
+
+> **Predicate semantics.** Under the hood the validator requires
+> `email` to be present **and** the predicate to return truthy. If you
+> want the inverse — "email is allowed-but-not-required when role is
+> admin" — combine `optional: true` with a manual `validate` check
+> instead. See [`validation.md`](./validation.md) for the manual route.
+
+## `inputs` — bulk declaration
+
+`inputs` takes a list of names and applies the same `type:` /
+`options` to all of them. Use it when several inputs share a shape:
+
+```ruby
+class ShipAddress < Assistant::Service
+  inputs %i[street city zip], type: String, required: true
+
+  def execute
+    "#{street}, #{city} #{zip}"
+  end
+end
+```
+
+This is exactly equivalent to writing three `input` calls.
+
+## Reading inputs back: `#input_snapshot`
+
+`#input_snapshot` returns a frozen `Data` instance carrying the
+post-default, post-`allow_nil` values. It's useful for forwarding the
+inputs of one service into another, for instrumentation, or for tests
+that want a structural snapshot:
+
+```ruby
+class CreateUser < Assistant::Service
+  input :email, type: String, required: true
+  input :role,  type: Symbol, default: :member
+
+  def execute
+    [input_snapshot.email, input_snapshot.role]
+  end
+end
+
+CreateUser.run(email: 'a@b.com').fetch(:result)
+# => ["a@b.com", :member]
+```
+
+See [`composing-services.md`](./composing-services.md) for a worked
+example that snapshots the outer service's inputs into an inner one.
+
+## Using `assistant-rbs` for Steep users
+
+`Assistant::Service` is metaprogramming-heavy: per-input methods are
+generated at class-definition time by `Service.input`, which means a
+generic `.rbs` for `Service` can't know that your `CreateUser#email`
+returns `String`. That's R1 in
+[`docs/v1/05-quality-and-tooling.md`](../v1/05-quality-and-tooling.md).
+
+The bundled `assistant-rbs` CLI (M11) closes the gap by emitting
+per-class `.rbs` files. Run it once after editing your services:
+
+```sh
+bundle exec assistant-rbs lib --output sig
+```
+
+For the `CreateUser` example above it writes
+`sig/CreateUser.rbs` with:
+
+```rbs
+class CreateUser < Assistant::Service
+  def email: () -> String
+  def email?: () -> bool
+  def role: () -> Symbol
+  def role?: () -> bool
+end
+```
+
+Multi-type inputs produce union types
+(`String | Integer`), and `allow_nil: true` produces nullable types
+(`String?`). The generator is idempotent — re-running with no input
+changes is a no-op.
+
+The CLI is labelled **Experimental** for 1.0 because its output
+format may evolve in 1.x; see
+[`api-reference.md`](../api-reference.md#assistant-rbs-cli) for the
+stability label.
+
+## Common pitfalls
+
+- **Passing a positional name to the constructor.** `Service.new('a')`
+  always raises. Call `Service.new(email: 'a')`, or just use
+  `Service.run(email: 'a')`.
+- **Sharing a mutable default literal.** `default: []` would share
+  one array across calls; the gem warns and recommends a lambda
+  (`default: -> { [] }`).
+- **Mixing `required: true` with `optional: true`.** They contradict
+  each other; the gem raises at class-definition time.
+- **Expecting `if:` to inhibit presence.** The validator requires
+  presence *and* the predicate. Use `optional: true` plus a `validate`
+  hook when you need the inverse.
+
+## See also
+
+- [Validation guide](./validation.md) — `validate` hook, when to log a
+  warning vs. error.
+- [Logging and results](./logging-and-results.md) — `LogItem`,
+  `log_item_*` shorthands, the result hash.
+- [Composing services](./composing-services.md) — `call_service`,
+  callbacks, `#input_snapshot` between services.
+- [API reference: class methods](../api-reference.md#class-methods).
+- [API reference: generated per-input methods](../api-reference.md#generated-per-input-methods).

--- a/docs/guides/logging-and-results.md
+++ b/docs/guides/logging-and-results.md
@@ -1,0 +1,196 @@
+<!-- markdownlint-disable MD013 MD024 -->
+# Logging and results
+
+> **TL;DR** — Every service maintains a `#logs` timeline of
+> `Assistant::LogItem`s. Use `log_item_info / _warning / _error` to
+> add entries, `#logs` / `#infos` / `#warnings` / `#errors` to read
+> them, and the result hash returned by `.run` to consume the
+> service from outside. `LogItem.new` raises `ArgumentError` for
+> invalid attributes (M10) — prefer the helpers.
+
+This guide covers the data model, the writer helpers, the reader
+predicates, and the shape of the result hash. See the
+[Validation guide](./validation.md) for *when* to log a warning vs.
+an error.
+
+## `Assistant::LogItem` at a glance
+
+Every entry on `#logs` is an `Assistant::LogItem` with the following
+fields:
+
+| Field      | Type                           | Notes                                                          |
+|------------|--------------------------------|----------------------------------------------------------------|
+| `level`    | `Symbol`                       | One of `:info`, `:warning`, `:error`.                          |
+| `source`   | `Symbol`                       | High-level subsystem (`:initialize`, `:execute`, `:hook`, ...).|
+| `detail`   | `Symbol`                       | Finer-grained tag; usually an input attribute name.            |
+| `message`  | `String`                       | Human-readable text.                                           |
+| `trace`    | `Array<String>` or `nil`       | Optional backtrace captured at construction.                   |
+
+Constraints (enforced strictly in 1.0 — M10):
+
+- `source != detail`.
+- `source` and `detail` must each be non-empty.
+- `message` must contain at least one non-whitespace character.
+- `level` must be one of `Assistant::LogItem::VALID_LEVELS`.
+
+```ruby
+Assistant::LogItem::VALID_LEVELS
+# => [:info, :warning, :error]
+```
+
+## Writing log entries
+
+The three shorthand helpers (M5) are the recommended call sites
+inside `#validate` and `#execute`:
+
+```ruby
+class CreateUser < Assistant::Service
+  input :email, type: String, required: true
+  input :age,   type: Integer, allow_nil: true, default: nil
+
+  def validate
+    return if email.include?('@')
+
+    log_item_error(source: :validate, detail: :email, message: 'invalid email')
+  end
+
+  def execute
+    log_item_info(source: :execute, detail: :age, message: "age=#{age.inspect}")
+    log_item_warning(source: :execute, detail: :age, message: 'age missing') if age.nil?
+
+    { id: 42, email:, age: }
+  end
+end
+```
+
+`add_log(level:, source:, detail:, message:, trace: nil)` is the
+generic form when you need to set the level dynamically:
+
+```ruby
+level = problem.severe? ? :error : :warning
+add_log(level:, source: :execute, detail: :payment, message: problem.to_s)
+```
+
+`#log_item_error_initialize(attr_name:, message:)` is used internally
+by the generated `valid_required_*?` / `valid_type_*?` validators to
+record per-input errors. Service code can call it directly when an
+ad-hoc validation needs the same `:initialize` source as the
+declarative checks.
+
+## Reading log entries
+
+A service exposes three readers, one per level, plus the full
+timeline:
+
+| Method        | Returns                              |
+|---------------|--------------------------------------|
+| `#logs`       | `Array<LogItem>` — every entry, in insertion order. |
+| `#infos`      | `Array<LogItem>` — entries with `level == :info`.   |
+| `#warnings`   | `Array<LogItem>` — entries with `level == :warning`.|
+| `#errors`     | `Array<LogItem>` — entries with `level == :error`.  |
+
+```ruby
+service = CreateUser.new(email: 'a@b.com')
+service.run
+
+service.logs.size      # => however many entries
+service.infos.first.message
+service.warnings.any?
+service.errors.empty?
+```
+
+`#status` is derived from `#errors` and `#warnings`:
+
+- `:with_errors` if `#errors.any?`.
+- `:with_warnings` if `#warnings.any?` and no errors.
+- `:ok` otherwise.
+
+`#success?` is `true` for `:ok` and `:with_warnings`; `#failure?` is
+`true` only for `:with_errors`.
+
+## The result hash
+
+`Service.run` (and `Service#run`) returns one of two shapes:
+
+```ruby
+# Success — status is :ok or :with_warnings
+{ result: <Object>, status: :ok | :with_warnings, warnings: Array<LogItem> }
+
+# Failure — :with_errors
+{ result: nil, status: :with_errors, errors: Array<LogItem> }
+```
+
+The success shape always includes `:warnings` (possibly empty); the
+failure shape always includes `:errors` (always non-empty) and
+`result: nil`. Pattern-matching is the cleanest way to consume it:
+
+```ruby
+case CreateUser.run(email: 'a@b.com')
+in { result:, status: :ok }
+  result
+in { result:, status: :with_warnings, warnings: }
+  WarningsLogger.log(warnings)
+  result
+in { errors:, status: :with_errors }
+  raise Errors::InvalidRequest, errors.map(&:message).join(', ')
+end
+```
+
+`#infos` are intentionally **not** part of the result hash. They live
+on the service instance for inspection (and for tests), but the
+public contract is the warnings/errors split.
+
+## Merging logs across services
+
+`#merge_logs(logs:)` concatenates another timeline onto the current
+service's `#logs`. It's mostly used by `#call_service` (see
+[`composing-services.md`](./composing-services.md)), but you can call
+it directly when you need to forward log items from a non-`Service`
+collaborator:
+
+```ruby
+def execute
+  outcome = MyLibrary.do_thing
+  merge_logs(logs: outcome.log_items.map { |item| Assistant::LogItem.new(**item) })
+  outcome.value
+end
+```
+
+> **M12.** `#merge_logs` is keyword-only in 1.0. Passing positional
+> arguments raises `ArgumentError`. The
+> [migration guide](../v1/06-migration-0x-to-1.md) covers the
+> mechanical rewrite.
+
+## Inspecting an entry
+
+Every `LogItem` has a `#item` method that returns a `Hash` view —
+handy for JSON serialization or test assertions:
+
+```ruby
+service.errors.first.item
+# => { level: :error, source: :validate, detail: :email,
+#      message: "invalid email", trace: nil }
+```
+
+## Common pitfalls
+
+- **Pushing onto `@logs` directly.** Don't — always go through the
+  helpers so the M10 strict construction runs and so future
+  middleware (e.g. an instrumentation hook around `#add_log`) can
+  see the entry.
+- **Using `LogItem.new` with `source == detail`.** Raises
+  `ArgumentError`. Pick distinct symbols.
+- **Treating `#infos` as part of the contract.** They're for
+  introspection only; the result hash never includes them.
+- **Calling `merge_logs(other.logs)` (positional).** M12 requires
+  the keyword form: `merge_logs(logs: other.logs)`.
+
+## See also
+
+- [Validation guide](./validation.md) — choosing warning vs. error,
+  conditional checks, `#validate` mechanics.
+- [Composing services](./composing-services.md) — how `#call_service`
+  merges inner logs into the outer timeline.
+- [API reference: LogItem](../api-reference.md#assistantlogitem).
+- [API reference: LogList](../api-reference.md#assistantloglist).
+- [Migration guide](../v1/06-migration-0x-to-1.md) for M10 + M12.

--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -1,0 +1,174 @@
+<!-- markdownlint-disable MD013 MD024 -->
+# Validation
+
+> **TL;DR** — Declarative `input` checks (`type:`, `required:`,
+> `if:`, etc.) run automatically before `#execute`. For everything
+> else, override `#validate` and call `log_item_error(...)` to
+> short-circuit, or `log_item_warning(...)` to flag a recoverable
+> issue. `LogItem.new` raises `ArgumentError` for invalid attributes
+> in 1.0 — use the helpers, not `LogItem.new` directly.
+
+This guide covers the validation surface beyond the declarative
+options on [`input`](./inputs.md): the `validate` hook, the
+warning-vs-error decision, the strict `LogItem` constructor, and
+conditional patterns.
+
+## What runs automatically
+
+For every `Service.input :name, type: T, required: ..., if: ...`,
+the gem generates and runs:
+
+- `#valid_type_name?` — type check (or multi-type with M3 union).
+- `#valid_required_name?` — presence check, when `required: true`.
+- `#valid_required_conditional_name?` — presence + predicate, when
+  `required: true` *and* `if:` are both supplied.
+
+`#run` calls every `valid_required_*?`, `valid_required_conditional_*?`,
+and `valid_type_*?` method that matches by naming convention before
+calling your `#validate`. Failures are logged as error-level
+`LogItem`s and short-circuit `#execute`.
+
+## Adding your own checks with `#validate`
+
+Override `#validate` to log domain-specific errors:
+
+```ruby
+class CreateUser < Assistant::Service
+  input :email, type: String, required: true
+
+  def validate
+    return if email.include?('@')
+
+    log_item_error(source: :validate, detail: :email, message: 'must contain @')
+  end
+
+  def execute
+    { email: }
+  end
+end
+
+CreateUser.run(email: 'a@b.com').fetch(:status) # => :ok
+CreateUser.run(email: 'oops').fetch(:status)    # => :with_errors
+```
+
+`#validate` runs **after** the declarative checks. If a declarative
+check already added an error, your `#validate` still runs (it has the
+chance to surface additional context), but `#execute` is skipped.
+
+## Warning vs. error: how to choose
+
+| Level     | Helper                  | Effect                                                                          |
+|-----------|-------------------------|---------------------------------------------------------------------------------|
+| `:info`   | `log_item_info(...)`    | Recorded on `#logs`; does not affect `#status`.                                 |
+| `:warning`| `log_item_warning(...)` | Flips `#status` from `:ok` to `:with_warnings`; `#execute` still runs.          |
+| `:error`  | `log_item_error(...)`   | Flips `#status` to `:with_errors`; `#execute` is **skipped**, `#result` is nil. |
+
+Rule of thumb:
+
+- **Use an error** when continuing would produce an invalid or
+  misleading result (`#execute` would have to handle the bad state).
+- **Use a warning** when the result is still meaningful but the
+  caller should know something is off (a missing optional input, an
+  in-progress migration shape, a deprecated value).
+
+A worked example:
+
+```ruby
+class CreateUser < Assistant::Service
+  input :email, type: String,  required: true
+  input :age,   type: Integer, allow_nil: true, default: nil
+
+  def validate
+    log_item_error(source: :validate, detail: :email, message: 'invalid email') unless email.include?('@')
+    log_item_warning(source: :validate, detail: :age, message: 'age missing') if age.nil?
+  end
+
+  def execute
+    { email:, age: }
+  end
+end
+
+CreateUser.run(email: 'a@b.com').fetch(:status)
+# => :with_warnings — age is missing, but we still build the result
+
+CreateUser.run(email: 'oops').fetch(:status)
+# => :with_errors — execute is skipped
+```
+
+## Conditional requirements
+
+When a presence check should fire only sometimes, combine
+`required: true` with `if:`:
+
+```ruby
+class UpdateUser < Assistant::Service
+  input :role,   type: Symbol, default: :member
+  input :reason, type: String, required: true, if: ->(_value) { true }
+
+  def execute
+    { role:, reason: }
+  end
+end
+
+UpdateUser.run(role: :member).fetch(:status)
+# => :with_errors — predicate is truthy, so :reason is required
+
+UpdateUser.run(role: :member, reason: 'audit cleanup').fetch(:status)
+# => :ok
+```
+
+The `if:` predicate is called with the *input's own value*. The
+validator requires the input to be present **and** the predicate to
+be truthy — so the canonical use is "I need this to be present
+*when* some other condition holds". See
+[`inputs.md`](./inputs.md#if--conditional-requirement) for the
+inverse pattern.
+
+## `LogItem.new` raises in 1.0 (M10)
+
+Constructing a `LogItem` directly with invalid attributes now raises
+`ArgumentError`. The `#valid?` family is kept for introspection but
+always returns `true` after a successful `new`:
+
+```ruby
+Assistant::LogItem.new(level: :info, source: :a, detail: :b, message: 'ok').valid?
+# => true
+
+begin
+  Assistant::LogItem.new(level: :info, source: :a, detail: :b, message: '')
+rescue ArgumentError => e
+  e.message # => "invalid LogItem: message must be present"
+end
+```
+
+Inside a `Service`, you almost never need `LogItem.new` directly:
+`log_item_info(...)`, `log_item_warning(...)`, `log_item_error(...)`,
+and `add_log(level:, source:, detail:, message:)` build the item and
+append it to `#logs` for you. See
+[`logging-and-results.md`](./logging-and-results.md) for the full
+catalogue.
+
+## Common pitfalls
+
+- **Returning `false` from `#validate` to signal failure.** The hook's
+  return value is ignored. The only way to fail is to log an
+  error-level `LogItem`.
+- **Calling `raise` inside `#validate` or `#execute`.** Don't —
+  `assistant` is soft-fail. Convert expected failures into log items.
+  Unexpected exceptions propagate (the gem catches exceptions only
+  in `before_execute` / `around_execute` / `after_execute` hooks).
+- **Building `LogItem.new(...)` and pushing it onto `#logs`.** Use the
+  helpers; they apply the same M10 strict construction and keep your
+  call sites readable.
+- **Forgetting that `#validate` runs even when a declarative check
+  already failed.** Either guard `#validate` with `return if
+  errors.any?`, or design it to add complementary errors.
+
+## See also
+
+- [Inputs guide](./inputs.md) — `required:`, `if:`, multi-type, the
+  generated `valid_*` predicates.
+- [Logging and results](./logging-and-results.md) — the helpers, the
+  full result hash, log filtering.
+- [API reference: LogItem](../api-reference.md#assistantlogitem).
+- [API reference: LogList](../api-reference.md#assistantloglist).

--- a/docs/v1/03-documentation.md
+++ b/docs/v1/03-documentation.md
@@ -35,10 +35,10 @@ contains `TODO` placeholders. v1 must ship a complete, navigable set of docs.
 | File                                  | Status | Contents                                                                  |
 |---------------------------------------|--------|---------------------------------------------------------------------------|
 | `docs/getting-started.md`             | [x] shipped | Install, first service, running it, reading the result hash, status enum. |
-| `docs/guides/inputs.md`               | [ ] follow-up PR | `input` / `inputs`, type checks, `required:`, `optional:`, `if:`, `default:`, `allow_nil:`, multi-type; "Using `bin/assistant-rbs`" subsection (M11) explaining the per-class RBS generator and R1's metaprogramming limitation. |
-| `docs/guides/validation.md`           | [ ] follow-up PR | `validate` hook, when to log warnings vs errors, conditional requirements. Note that `LogItem.new` is now strict (M10). |
-| `docs/guides/logging-and-results.md`  | [ ] follow-up PR | `LogItem` shape and **strict construction** (M10), levels, `add_log`, `merge_logs`, the `log_item_info/warning/error` shorthands (M5), `#logs` / `#warnings` / `#errors`, result hash. |
-| `docs/guides/composing-services.md`   | [ ] follow-up PR | Manual composition today; `call_service` (M-S2); error/warning propagation rules; using callbacks (M-S1) and the instrumentation notifier (M-S3); reading `#input_snapshot` (M-S4). |
+| `docs/guides/inputs.md`               | [x] shipped | `input` / `inputs`, type checks, `required:`, `optional:`, `if:`, `default:`, `allow_nil:`, multi-type; "Using `bin/assistant-rbs`" subsection (M11) explaining the per-class RBS generator and R1's metaprogramming limitation. |
+| `docs/guides/validation.md`           | [x] shipped | `validate` hook, when to log warnings vs errors, conditional requirements. Note that `LogItem.new` is now strict (M10). |
+| `docs/guides/logging-and-results.md`  | [x] shipped | `LogItem` shape and **strict construction** (M10), levels, `add_log`, `merge_logs`, the `log_item_info/warning/error` shorthands (M5), `#logs` / `#warnings` / `#errors`, result hash. |
+| `docs/guides/composing-services.md`   | [x] shipped | Manual composition today; `call_service` (M-S2); error/warning propagation rules; using callbacks (M-S1) and the instrumentation notifier (M-S3); reading `#input_snapshot` (M-S4). |
 | `docs/api-reference.md`               | [x] shipped | Curated, hand-written reference of every Frozen symbol from `01-api-surface.md`. Auto-generation deferred. |
 | `docs/deprecations.md`                | [x] shipped (M9) | Created as part of M9; first entry documents the `valid_require_*?` → `valid_required_*?` deprecation. |
 
@@ -122,12 +122,12 @@ regression test under `test/examples/<slug>_example_test.rb`.
 - [ ] Every link in `docs/**/*.md` is reachable
       (`bundle exec rake docs:check_links` — implementation deferred; manual
       pass acceptable for 1.0).
-- [ ] `bundle exec yard stats --list-undoc` reports 100% documented public
+- [x] `bundle exec yard stats --list-undoc` reports 100% documented public
       methods.
-- [ ] Each guide page has at least one tested example: every code block
+- [x] Each guide page has at least one tested example: every code block
       tagged ```` ```ruby ```` in `docs/getting-started.md` and
       `docs/guides/*.md` is mirrored by an integration test in
-      `test/docs/<guide>_examples_test.rb` (a new directory).
+      `test/docs/<guide>_examples_test.rb` — shipped in the D2 guides PR.
 
 ## Out of scope for v1 docs
 

--- a/docs/v1/05-quality-and-tooling.md
+++ b/docs/v1/05-quality-and-tooling.md
@@ -29,8 +29,16 @@ Today the suite is Minitest under `test/` (per the 0.1.0 migration noted in
       easy inspection on PRs.
 - [x] Add a CI step that prints line/branch percentages to the GitHub
       Actions job summary (`$GITHUB_STEP_SUMMARY`).
-- [ ] Add `test/docs/` for example-block tests required by
-      [`03-documentation.md`](./03-documentation.md) D5 acceptance criteria.
+- [x] Add `test/docs/` for example-block tests required by
+      [`03-documentation.md`](./03-documentation.md) D5 acceptance
+      criteria. Shipped: `test/docs/getting_started_examples_test.rb`,
+      `test/docs/inputs_guide_examples_test.rb`,
+      `test/docs/validation_guide_examples_test.rb`,
+      `test/docs/logging_and_results_guide_examples_test.rb`,
+      `test/docs/composing_services_guide_examples_test.rb` — each
+      mirrors the runnable examples in its sibling `docs/` page so
+      drift in literal error messages, hook ordering, or result-hash
+      shape breaks the matching assertion.
 
 ## RuboCop
 
@@ -150,16 +158,14 @@ public Frozen surface. Q6 was decided in favour of
       `target :examples` block. The `Steep` job in
       `.github/workflows/ci.yml:43` runs `bundle exec steep check
       --jobs=1` and is required by branch protection.
-- [ ] Document the limitation that `Service.input(:foo, ...)`-generated
+- [x] Document the limitation that `Service.input(:foo, ...)`-generated
       methods cannot be expressed precisely in RBS by hand on the gem
       side; users generate per-class sigs with `bin/assistant-rbs` (M11).
-      Surface this in `docs/guides/inputs.md` per D2 in
-      [`03-documentation.md`](./03-documentation.md). The limitation is
-      documented in the gem internals (`lib/assistant/service.rbs:1-10`,
-      `Steepfile:8-21`) and in
-      [`06-migration-0x-to-1.md`](./06-migration-0x-to-1.md) "Recipe:
-      `bin/assistant-rbs` for Steep users"; the user-facing guide ships
-      with D2.
+      Surfaced in `docs/guides/inputs.md` ("Using `bin/assistant-rbs`
+      for Steep users" subsection); also documented in the gem
+      internals (`lib/assistant/service.rbs:1-10`, `Steepfile:8-21`)
+      and in [`06-migration-0x-to-1.md`](./06-migration-0x-to-1.md)
+      "Recipe: `bin/assistant-rbs` for Steep users".
 
 ## CI matrix
 

--- a/test/docs/composing_services_guide_examples_test.rb
+++ b/test/docs/composing_services_guide_examples_test.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Integration tests mirroring the runnable examples in
+# docs/guides/composing-services.md.
+class ComposingServicesGuideExamplesTest < Minitest::Test
+  include TestHelpers::IoCapture
+
+  class CreateUser < Assistant::Service
+    input :email, type: String, required: true
+    def execute = { id: 1, email: }
+  end
+
+  class SignUp < Assistant::Service
+    input :email, type: String, required: true
+
+    def execute
+      user = call_service(CreateUser, email:)
+      return if user.failure?
+
+      { user: user.result, signed_up_at: Time.now }
+    end
+  end
+
+  def test_call_service_success_path
+    payload = SignUp.run(email: 'a@b.com')
+
+    assert_equal :ok, payload.fetch(:status)
+    assert_equal 1, payload.fetch(:result).fetch(:user).fetch(:id)
+  end
+
+  def test_call_service_propagates_inner_failure_to_outer_status
+    payload = SignUp.run(email: '')
+
+    assert_equal :with_errors, payload.fetch(:status)
+    assert_nil payload.fetch(:result)
+  end
+
+  def test_call_service_rejects_non_service_class
+    err = assert_raises(ArgumentError) do
+      Class.new(Assistant::Service) do
+        define_method(:execute) { call_service(String, foo: 1) }
+      end.run
+    end
+    assert_match(/expects an Assistant::Service subclass/, err.message)
+  end
+
+  class HookedService < Assistant::Service
+    input :email, type: String, required: true
+
+    before_execute do
+      log_item_info(source: :hook, detail: :before, message: "starting #{email}")
+    end
+
+    around_execute do |&blk|
+      log_item_info(source: :hook, detail: :around_in, message: 'around in')
+      value = blk.call
+      log_item_info(source: :hook, detail: :around_out, message: 'around out')
+      value
+    end
+
+    after_execute do |result|
+      log_item_info(source: :hook, detail: :after, message: "result=#{result.inspect}")
+    end
+
+    def execute = { id: 1, email: }
+  end
+
+  def test_hooks_run_in_documented_order
+    svc = HookedService.new(email: 'a@b.com')
+    svc.run
+
+    sequence = svc.infos.map(&:detail)
+
+    assert_equal %i[before around_in around_out after], sequence
+  end
+
+  def test_hook_block_required
+    assert_raises(ArgumentError) do
+      Class.new(Assistant::Service) { before_execute }
+    end
+  end
+
+  class ChildHooked < HookedService
+    before_execute do
+      log_item_info(source: :hook, detail: :before_child, message: 'child')
+    end
+  end
+
+  def test_hook_inheritance_is_a_dup
+    parent_count = HookedService.before_execute_hooks.size # force registration via the before_execute block above
+
+    assert_equal parent_count, HookedService.before_execute_hooks.size
+    assert_equal parent_count + 1, ChildHooked.before_execute_hooks.size
+  end
+
+  class NotifierService < Assistant::Service
+    input :name, type: String, required: true
+    def execute = name.upcase
+  end
+
+  def test_notifier_receives_lifecycle_events_with_payload
+    events = []
+    Assistant.notifier = ->(event, payload) { events << [event, payload[:service_class]] }
+
+    NotifierService.run(name: 'ada')
+
+    event_names = events.map(&:first)
+
+    assert_includes event_names, :service_started
+    assert_includes event_names, :service_validated
+    assert_includes event_names, :service_executed
+    assert(events.all? { |_, klass| klass == NotifierService })
+  ensure
+    Assistant.notifier = nil
+  end
+
+  def test_notifier_failure_emits_service_failed
+    events = []
+    Assistant.notifier = ->(event, _payload) { events << event }
+
+    NotifierService.run # missing required :name -> :with_errors
+
+    assert_includes events, :service_failed
+  ensure
+    Assistant.notifier = nil
+  end
+
+  def test_notifier_exception_is_swallowed_with_warning
+    Assistant.notifier = ->(_event, _payload) { raise 'boom' }
+
+    err = capture_io_warn { NotifierService.run(name: 'ada') }
+
+    assert_match(/notifier raised/, err)
+  ensure
+    Assistant.notifier = nil
+  end
+
+  class Snapshotter < Assistant::Service
+    input :email, type: String, required: true
+    input :role,  type: Symbol, default: :member
+
+    def execute = input_snapshot.to_h
+  end
+
+  def test_input_snapshot_is_immutable_data_view
+    instance = Snapshotter.new(email: 'a@b.com')
+    instance.run
+    snap = instance.input_snapshot
+
+    assert_kind_of Data, snap
+    assert_equal 'a@b.com', snap.email
+    assert_equal :member,   snap.role
+    assert_equal({ email: 'a@b.com', role: :member }, snap.to_h)
+  end
+end

--- a/test/docs/getting_started_examples_test.rb
+++ b/test/docs/getting_started_examples_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Integration tests mirroring the runnable examples in
+# docs/getting-started.md. The intent is to keep the docs honest:
+# if a literal output in the markdown drifts from runtime behavior,
+# the matching assertion here breaks.
+class GettingStartedExamplesTest < Minitest::Test
+  class CreateUser < Assistant::Service
+    input :email, type: String,  required: true
+    input :age,   type: Integer, allow_nil: true, default: nil
+
+    def validate
+      return if email.include?('@')
+
+      log_item_error(source: :validate, detail: :email, message: 'must contain @')
+    end
+
+    def execute
+      log_item_warning(source: :execute, detail: :age, message: 'age missing') if age.nil?
+
+      { id: 42, email:, age: }
+    end
+  end
+
+  def test_happy_path_returns_ok_status
+    payload = CreateUser.run(email: 'a@b.com', age: 30)
+
+    assert_equal :ok, payload.fetch(:status)
+    assert_equal({ id: 42, email: 'a@b.com', age: 30 }, payload.fetch(:result))
+    assert_empty payload.fetch(:warnings)
+  end
+
+  def test_missing_age_demotes_to_with_warnings
+    payload = CreateUser.run(email: 'a@b.com')
+
+    assert_equal :with_warnings, payload.fetch(:status)
+    assert_equal({ id: 42, email: 'a@b.com', age: nil }, payload.fetch(:result))
+    assert_equal 1, payload.fetch(:warnings).size
+  end
+
+  def test_invalid_email_yields_with_errors
+    payload = CreateUser.run(email: 'oops')
+
+    assert_equal :with_errors, payload.fetch(:status)
+    assert_nil payload.fetch(:result)
+    refute_empty payload.fetch(:errors)
+  end
+
+  def test_pattern_match_consumption_shape
+    payload = CreateUser.run(email: 'a@b.com', age: 30)
+
+    extracted =
+      case payload
+      in { result:, status: :ok | :with_warnings }
+        result
+      in { errors:, status: :with_errors }
+        errors
+      end
+
+    assert_equal({ id: 42, email: 'a@b.com', age: 30 }, extracted)
+  end
+end

--- a/test/docs/inputs_guide_examples_test.rb
+++ b/test/docs/inputs_guide_examples_test.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Integration tests mirroring the runnable examples in docs/guides/inputs.md.
+class InputsGuideExamplesTest < Minitest::Test
+  class TypeChecked < Assistant::Service
+    input :email, type: String
+
+    def execute = email
+  end
+
+  def test_type_mismatch_message_matches_doc_literal
+    payload = TypeChecked.run(email: 42)
+
+    assert_equal :with_errors, payload.fetch(:status)
+    err = payload.fetch(:errors).first
+
+    assert_equal :email, err.detail
+    assert_equal 'Service argument with name email is not a String but Integer', err.message
+  end
+
+  class MultiType < Assistant::Service
+    input :id, type: [String, Integer]
+
+    def execute = id
+  end
+
+  def test_multi_type_accepts_either
+    assert_equal :ok, MultiType.run(id: 'abc').fetch(:status)
+    assert_equal :ok, MultiType.run(id: 7).fetch(:status)
+  end
+
+  def test_multi_type_rejects_outsider
+    payload = MultiType.run(id: :sym)
+
+    assert_equal :with_errors, payload.fetch(:status)
+    assert_match(/not one of \[String, Integer\] but Symbol/, payload.fetch(:errors).first.message)
+  end
+
+  class RequiredOnly < Assistant::Service
+    input :email, type: String, required: true
+
+    def execute = email
+  end
+
+  def test_required_missing_message_matches_doc_literal
+    payload = RequiredOnly.run(email: '')
+
+    assert_equal :with_errors, payload.fetch(:status)
+    err = payload.fetch(:errors).first
+
+    assert_equal :email, err.detail
+    assert_equal 'Service is missing argument with name email', err.message
+  end
+
+  class WithDefault < Assistant::Service
+    input :role, type: Symbol, default: :member
+
+    def execute = role
+  end
+
+  def test_default_fires_when_key_absent
+    assert_equal :member, WithDefault.run.fetch(:result)
+    assert_equal :admin,  WithDefault.run(role: :admin).fetch(:result)
+  end
+
+  def test_proc_default_must_be_zero_arity
+    err = assert_raises(ArgumentError) do
+      Class.new(Assistant::Service) do
+        input :uuid, type: String, default: ->(svc) { svc.object_id.to_s }
+      end
+    end
+    assert_match(/arity/i, err.message)
+  end
+
+  class AllowNilTypeCheck < Assistant::Service
+    input :age, type: Integer, allow_nil: true
+
+    def execute = age
+  end
+
+  def test_allow_nil_passes_type_check_with_explicit_nil
+    payload = AllowNilTypeCheck.run(age: nil)
+
+    assert_equal :ok, payload.fetch(:status)
+    assert_nil payload.fetch(:result)
+  end
+
+  class OptionalNickname < Assistant::Service
+    input :nickname, type: String, optional: true
+
+    def execute = nickname.to_s.upcase
+  end
+
+  def test_optional_input_does_not_error_when_missing
+    payload = OptionalNickname.run
+
+    assert_equal :ok, payload.fetch(:status)
+    assert_equal '', payload.fetch(:result)
+  end
+
+  def test_optional_collides_with_required_at_class_definition
+    err = assert_raises(ArgumentError) do
+      Class.new(Assistant::Service) do
+        input :nope, type: String, required: true, optional: true
+      end
+    end
+    assert_match(/cannot be both required: true and optional: true/, err.message)
+  end
+
+  class ConditionalRequire < Assistant::Service
+    input :role,   type: Symbol, default: :member
+    input :reason, type: String, required: true, if: ->(_value) { true }
+
+    def execute = { role:, reason: }
+  end
+
+  def test_conditional_required_predicate_receives_input_value
+    assert_equal :with_errors, ConditionalRequire.run(role: :member).fetch(:status)
+    assert_equal :ok, ConditionalRequire.run(role: :member, reason: 'audit').fetch(:status)
+  end
+
+  class Bulk < Assistant::Service
+    inputs %i[first last], type: String, required: true
+
+    def execute = "#{first} #{last}"
+  end
+
+  def test_inputs_bulk_declares_all_attrs
+    assert_equal 'Ada Lovelace', Bulk.run(first: 'Ada', last: 'Lovelace').fetch(:result)
+  end
+
+  class Snapshotter < Assistant::Service
+    input :email, type: String, required: true
+    input :role,  type: Symbol, default: :member
+
+    def execute = input_snapshot.to_h
+  end
+
+  def test_input_snapshot_is_a_data_view_of_declared_inputs
+    instance = Snapshotter.new(email: 'a@b.com')
+    instance.run
+    snap = instance.input_snapshot
+
+    assert_kind_of Data, snap
+    assert_equal 'a@b.com', snap.email
+    assert_equal :member,   snap.role
+    assert_equal({ email: 'a@b.com', role: :member }, snap.to_h)
+  end
+end

--- a/test/docs/logging_and_results_guide_examples_test.rb
+++ b/test/docs/logging_and_results_guide_examples_test.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Integration tests mirroring the runnable examples in
+# docs/guides/logging-and-results.md.
+class LoggingAndResultsGuideExamplesTest < Minitest::Test
+  def test_valid_levels_is_frozen_three_symbol_array
+    assert_equal %i[info warning error], Assistant::LogItem::VALID_LEVELS
+  end
+
+  class Mixed < Assistant::Service
+    input :email, type: String,  required: true
+    input :age,   type: Integer, allow_nil: true, default: nil
+
+    def validate
+      return if email.include?('@')
+
+      log_item_error(source: :validate, detail: :email, message: 'invalid email')
+    end
+
+    def execute
+      log_item_info(source: :execute, detail: :age, message: "age=#{age.inspect}")
+      log_item_warning(source: :execute, detail: :age, message: 'age missing') if age.nil?
+
+      { id: 42, email:, age: }
+    end
+  end
+
+  def test_three_helpers_segregate_into_level_buckets
+    svc = Mixed.new(email: 'a@b.com')
+    svc.run
+
+    assert_equal 1, svc.infos.size
+    assert_equal 1, svc.warnings.size
+    assert_empty svc.errors
+    assert_equal :with_warnings, svc.status
+  end
+
+  def test_add_log_with_dynamic_level
+    svc = Mixed.new(email: 'a@b.com')
+    svc.send(:add_log, level: :warning, source: :execute, detail: :payment, message: 'flaky')
+
+    assert_equal 1, svc.warnings.size
+  end
+
+  def test_result_hash_success_shape
+    payload = Mixed.run(email: 'a@b.com', age: 30)
+
+    assert_equal :ok, payload.fetch(:status)
+    assert_equal({ id: 42, email: 'a@b.com', age: 30 }, payload.fetch(:result))
+    assert_empty payload.fetch(:warnings)
+  end
+
+  def test_result_hash_failure_shape
+    payload = Mixed.run(email: 'oops')
+
+    assert_equal :with_errors, payload.fetch(:status)
+    assert_nil payload.fetch(:result)
+    refute_empty payload.fetch(:errors)
+  end
+
+  def test_pattern_match_consumption_shape
+    payload = Mixed.run(email: 'a@b.com', age: 30)
+
+    matched =
+      case payload
+      in { result:, status: :ok }
+        result
+      in { result:, status: :with_warnings, warnings: }
+        [result, warnings]
+      in { errors:, status: :with_errors }
+        errors
+      end
+
+    assert_equal({ id: 42, email: 'a@b.com', age: 30 }, matched)
+  end
+
+  def test_infos_not_part_of_result_hash
+    payload = Mixed.run(email: 'a@b.com', age: 30)
+
+    refute_includes payload.keys, :infos
+  end
+
+  class Outer < Assistant::Service
+    def execute
+      merge_logs(logs: [Assistant::LogItem.new(level: :info, source: :outer, detail: :merge, message: 'merged')])
+      :done
+    end
+  end
+
+  def test_merge_logs_keyword_only_appends
+    payload = Outer.run
+
+    assert_equal :ok, payload.fetch(:status)
+  end
+
+  def test_merge_logs_positional_raises
+    svc = Outer.new
+    assert_raises(ArgumentError) { svc.merge_logs([]) }
+  end
+
+  def test_item_returns_hash_view
+    item = Assistant::LogItem.new(level: :error, source: :validate, detail: :email, message: 'invalid')
+
+    assert_equal({ level: :error, source: :validate, detail: :email, message: 'invalid', trace: nil }, item.item)
+  end
+end

--- a/test/docs/validation_guide_examples_test.rb
+++ b/test/docs/validation_guide_examples_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Integration tests mirroring the runnable examples in docs/guides/validation.md.
+class ValidationGuideExamplesTest < Minitest::Test
+  class CreateUserSimple < Assistant::Service
+    input :email, type: String, required: true
+
+    def validate
+      return if email.include?('@')
+
+      log_item_error(source: :validate, detail: :email, message: 'must contain @')
+    end
+
+    def execute = { email: }
+  end
+
+  def test_happy_path
+    assert_equal :ok, CreateUserSimple.run(email: 'a@b.com').fetch(:status)
+  end
+
+  def test_validate_logs_error_short_circuits_execute
+    payload = CreateUserSimple.run(email: 'oops')
+
+    assert_equal :with_errors, payload.fetch(:status)
+    assert_nil payload.fetch(:result)
+  end
+
+  class WarningVsError < Assistant::Service
+    input :email, type: String,  required: true
+    input :age,   type: Integer, allow_nil: true, default: nil
+
+    def validate
+      log_item_error(source: :validate, detail: :email, message: 'invalid email') unless email.include?('@')
+      log_item_warning(source: :validate, detail: :age, message: 'age missing') if age.nil?
+    end
+
+    def execute = { email:, age: }
+  end
+
+  def test_warning_does_not_skip_execute
+    payload = WarningVsError.run(email: 'a@b.com')
+
+    assert_equal :with_warnings, payload.fetch(:status)
+    assert_equal({ email: 'a@b.com', age: nil }, payload.fetch(:result))
+  end
+
+  def test_error_skips_execute
+    payload = WarningVsError.run(email: 'oops')
+
+    assert_equal :with_errors, payload.fetch(:status)
+    assert_nil payload.fetch(:result)
+  end
+
+  class UpdateUser < Assistant::Service
+    input :role,   type: Symbol, default: :member
+    input :reason, type: String, required: true, if: ->(_value) { true }
+
+    def execute = { role:, reason: }
+  end
+
+  def test_conditional_required_failure_and_success
+    assert_equal :with_errors, UpdateUser.run(role: :member).fetch(:status)
+    assert_equal :ok, UpdateUser.run(role: :member, reason: 'audit cleanup').fetch(:status)
+  end
+
+  def test_log_item_constructor_is_strict_in_one_zero
+    item = Assistant::LogItem.new(level: :info, source: :a, detail: :b, message: 'ok')
+
+    assert_predicate item, :valid?
+
+    err = assert_raises(ArgumentError) do
+      Assistant::LogItem.new(level: :info, source: :a, detail: :b, message: '')
+    end
+    assert_equal 'invalid LogItem: message must be present', err.message
+  end
+end


### PR DESCRIPTION
## Scope

Closes the remaining D2 work in
[`docs/v1/03-documentation.md`](docs/v1/03-documentation.md) (four
user-facing guides) plus the `test/docs/` and R1 user-facing-note
items in
[`docs/v1/05-quality-and-tooling.md`](docs/v1/05-quality-and-tooling.md).

## What ships

- Four new guides under `docs/guides/`:
  - `inputs.md` — DSL: `type:`, multi-type (M3), `required:`,
    `default:` (M1), `allow_nil:` (M2), `optional:` (M7), `if:`
    conditional, `inputs` bulk, `#input_snapshot` (M-S4), plus a
    "Using `bin/assistant-rbs` for Steep users" subsection covering
    R1 + the M11 CLI output.
  - `validation.md` — auto-validation regex, `#validate` hook,
    warning vs error vs info behaviour, conditional requirements,
    `LogItem.new` raising in 1.0 (M10).
  - `logging-and-results.md` — `LogItem` constraints, three
    shorthand helpers, the result hash for both success and failure
    shapes, `#merge_logs(logs:)` keyword-only (M12).
  - `composing-services.md` — `#call_service` (M-S2), execute
    callbacks (M-S1), instrumentation notifier (M-S3), and
    `#input_snapshot` (M-S4).
- One integration test per guide under `test/docs/` so the runnable
  examples can't silently drift from actual behaviour.
- `.yardopts` extended to include the four new guide pages.
- `docs/v1/03-documentation.md` D2 rows flipped to shipped.
- `docs/v1/05-quality-and-tooling.md` flips `test/docs/` and the R1
  user-facing-note bullets to shipped.
- `CHANGELOG.md` gains a D2 follow-up entry under `### Added`.

## Verification

\`\`\`
$ bundle exec rake ci
265 runs, 701 assertions, 0 failures, 0 errors, 0 skips
Line Coverage: 99.55% (439 / 441)
Branch Coverage: 95.65% (88 / 92)
Inspecting 45 files
45 files inspected, no offenses detected
No type error detected.
yard: 100.00% documented
\`\`\`

## Out of scope

- D5 examples gallery (P6–P12) — not a 1.0 gate per
  [`docs/v1/00-overview.md`](docs/v1/00-overview.md).
- D2 dedicated `docs/guides/rbs-and-types.md` standalone page — the
  R1 + M11 material lives inside `inputs.md` for 1.0 (and is enough
  to flip the R1 acceptance bullet); a standalone page can land as
  part of the parallel GitHub Pages site
  ([`docs/v1/08-github-pages.md`](docs/v1/08-github-pages.md)).
- Version bump + CHANGELOG `[1.0.0]` consolidation + RC tag — next PR.