### PR TITLE
release: prepare v1.0.0.rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0.rc1] - 2026-06-15
+
 ### Added
 
 - **D2 (follow-up)**: four user-facing guides under `docs/guides/` —
@@ -329,6 +331,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Assistant::Service#valid_require_conditional_<name>?` (use
   `#valid_required_conditional_<name>?` instead). Scheduled for removal
   in `assistant 2.0`. (M9, v1 plan)
+
+### Migration
+
+`1.0.0` is a stabilisation release. Three small breaking changes have
+to be addressed; every one is mechanical and `git grep`-able. The full
+recipe lives in
+[`docs/v1/06-migration-0x-to-1.md`](docs/v1/06-migration-0x-to-1.md).
+
+1. **`LogList#merge_logs` is keyword-only (M12, B3)** — rewrite every
+   `merge_logs(other.logs)` call site to `merge_logs(logs: other.logs)`.
+   The two public DSL entry points `Service.input` and `Service.inputs`
+   keep their leading positional `attr_name` / `attr_names`; only
+   `merge_logs` and the internal `InputBuilder` helpers changed.
+2. **`LogItem.new` raises on invalid attrs (M10, B1)** — audit any
+   direct `LogItem.new(...)` call sites. The gem's own call sites are
+   already correct; fixtures that exercised the old "constructs but
+   `valid? == false`" path need updating. Prefer the `add_log` /
+   `log_item_*` helpers in regular code.
+3. **`valid_require_*?` is deprecated (M9, B2)** — rename direct calls
+   to the new `valid_required_*?` form. Users who don't call these
+   predicates directly (driven internally by `validate_inputs`) need
+   no source change; the old name still works in 1.x with a one-time
+   `Kernel.warn` per call site, and is removed in 2.0.
+
+Pin to `~> 1.0` in your `Gemfile` once the upgrade lands.
 
 ## [0.1.0] - 2026-05-07
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    assistant (0.1.0)
+    assistant (1.0.0.rc1)
 
 GEM
   remote: https://rubygems.org/
@@ -130,7 +130,7 @@ DEPENDENCIES
   yard (~> 0.9)
 
 CHECKSUMS
-  assistant (0.1.0)
+  assistant (1.0.0.rc1)
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
   byebug (13.0.0) sha256=d2263efe751941ca520fa29744b71972d39cbc41839496706f5d9b22e92ae05d

--- a/docs/v1/04-release-checklist.md
+++ b/docs/v1/04-release-checklist.md
@@ -51,15 +51,26 @@
 
 ## Pre-release: source updates
 
-- [ ] Bump `Assistant::VERSION` to `'1.0.0'` in `lib/assistant/version.rb:4`.
-- [ ] Update `bin/version` (if it touches the constant) to keep it green.
-- [ ] Move all `[Unreleased]` entries in `CHANGELOG.md` under a new
+- [x] Bump `Assistant::VERSION` to `'1.0.0'` in `lib/assistant/version.rb:4`.
+      Bumped to `'1.0.0.rc1'` for the RC cut; the `1.0.0` bump rides
+      the follow-up release commit after the RC smoke passes.
+- [x] Update `bin/version` (if it touches the constant) to keep it green.
+      `bin/version` reads `Assistant::VERSION` at runtime; no edit
+      required and the `bin-smoke` CI job (added in PR #173)
+      keeps it honest.
+- [x] Move all `[Unreleased]` entries in `CHANGELOG.md` under a new
       `## [1.0.0] - YYYY-MM-DD` heading and add a `## [Unreleased]` empty
-      section above it.
-- [ ] In `CHANGELOG.md`, add a "Migration" subsection under `[1.0.0]`
+      section above it. Done for the RC: entries promoted to
+      `## [1.0.0.rc1] - 2026-06-15`; an empty `## [Unreleased]` sits
+      above it. The release PR retitles to `## [1.0.0]` with the tag
+      date.
+- [x] In `CHANGELOG.md`, add a "Migration" subsection under `[1.0.0]`
       summarizing [`06-migration-0x-to-1.md`](./06-migration-0x-to-1.md).
-- [ ] Tag the EOL of `0.x` in `SECURITY.md` (created in
+- [x] Tag the EOL of `0.x` in `SECURITY.md` (created in
       [`03-documentation.md`](./03-documentation.md)).
+      Already in place at
+      [`SECURITY.md:9-17`](../../SECURITY.md): "0.x — End of life on
+      the `1.0.0` release. No further fixes."
 
 ## Local pre-flight (run before pushing the tag)
 

--- a/lib/assistant/version.rb
+++ b/lib/assistant/version.rb
@@ -5,5 +5,5 @@ module Assistant
   # documented in `docs/v1/01-api-surface.md` from 1.0.0 onward.
   #
   # @return [String]
-  VERSION = '0.1.0'
+  VERSION = '1.0.0.rc1'
 end


### PR DESCRIPTION
## Scope

Closes the **Pre-release: source updates** block in
[`docs/v1/04-release-checklist.md`](docs/v1/04-release-checklist.md).
Stages the tree so the maintainer can tag \`v1.0.0.rc1\` and let
\`.github/workflows/release.yml\` publish via RubyGems trusted
publishing. Once the RC smoke passes (see the checklist), the
follow-up release PR bumps to \`1.0.0\` and re-titles the CHANGELOG
heading.

## What ships

- \`lib/assistant/version.rb\`: \`VERSION\` bumped to \`'1.0.0.rc1'\`.
- \`Gemfile.lock\`: \`PATH\` spec + \`CHECKSUMS\` line updated to match.
  Surgical edit; no dependency churn.
- \`CHANGELOG.md\`: every entry that lived under \`[Unreleased]\` is now
  under \`## [1.0.0.rc1] - 2026-06-15\`, with an empty \`## [Unreleased]\`
  above it. The new section gains a \`### Migration\` subsection that
  summarises [\`docs/v1/06-migration-0x-to-1.md\`](docs/v1/06-migration-0x-to-1.md)
  (the three mechanical rewrites: keyword-only \`merge_logs\`, strict
  \`LogItem.new\`, deprecated \`valid_require_*?\`).
- \`docs/v1/04-release-checklist.md\`: every item in
  *Pre-release: source updates* flips to \`[x]\` with explanatory
  notes.

## Sample output

\`\`\`
$ gem build assistant.gemspec
  Successfully built RubyGem
  Name: assistant
  Version: 1.0.0.rc1
  File: assistant-1.0.0.rc1.gem
\`\`\`

(The duplicate-homepage-URI warning is informational; \`spec.homepage\`
and \`metadata['homepage_uri']\` both point at the GitHub repo, which
\`spec.metadata['source_code_uri']\` also does.)

## Verification

\`\`\`
$ bundle exec rake ci
265 runs, 701 assertions, 0 failures, 0 errors, 0 skips
Line Coverage: 99.55% (439 / 441)
Branch Coverage: 95.65% (88 / 92)
45 files inspected, no offenses detected
No type error detected.
yard: 100.00% documented
\`\`\`

## Out of scope

- **The actual tag push** — pushing \`v1.0.0.rc1\` triggers the
  release workflow and publishes to RubyGems. The maintainer drives
  that step after this PR merges; see the *Pre-release: RC tag* block
  in
  [\`docs/v1/04-release-checklist.md\`](docs/v1/04-release-checklist.md).
- The follow-up \`v1.0.0\` PR (version bump from \`1.0.0.rc1\` →
  \`1.0.0\`, CHANGELOG retitled, post-release housekeeping items).
- D5 examples gallery — not a 1.0 gate per
  [\`docs/v1/00-overview.md\`](docs/v1/00-overview.md).