### PR TITLE
docs: scaffold mkdocs GitHub Pages site (P2)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,62 @@
+---
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - docs/**
+      - mkdocs.yml
+      - requirements-docs.txt
+      - .github/workflows/docs.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - docs/**
+      - mkdocs.yml
+      - requirements-docs.txt
+      - .github/workflows/docs.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: mkdocs build --strict
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: requirements-docs.txt
+      - name: Install docs toolchain
+        run: pip install -r requirements-docs.txt
+      - name: Build site
+        run: mkdocs build --strict
+      - name: Upload site artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /coverage/
 /doc/
 /pkg/
+/site/
 /spec/reports/
 /tmp/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **GitHub Pages — P2 scaffolding**: stood up the parallel mkdocs site
+  per [`docs/v1/08-github-pages.md`](docs/v1/08-github-pages.md). Ships
+  `mkdocs.yml` with the Material theme + indigo palette + light/dark
+  toggle + nav tree, a pinned `requirements-docs.txt` (`mkdocs`,
+  `mkdocs-material`, `mkdocs-material-extensions`,
+  `pymdown-extensions`, `Pygments`), the `.github/workflows/docs.yml`
+  CI workflow (PR builds `mkdocs build --strict`; pushes to `main`
+  deploy via `actions/deploy-pages`), `docs:install` / `docs:build` /
+  `docs:serve` Rake tasks, the `docs/index.md` landing page, and
+  placeholder stubs for `docs/guides/rbs-and-types.md`,
+  `docs/examples/{index,rails-service,cli-handler,sidekiq-worker,composing-services,execute-callbacks,instrumentation-notifier,rbs-generator}.md`,
+  `docs/roadmap.md`, and `docs/changelog.md`. Repository owner must
+  enable Pages source = "GitHub Actions" once in repo settings for the
+  first deploy to publish.
+
 ## [1.0.0.rc1] - 2026-06-15
 
 ### Added

--- a/Rakefile
+++ b/Rakefile
@@ -38,4 +38,21 @@ end
 desc 'Run the full local CI pipeline: test + rubocop + steep + yard'
 task ci: %i[test rubocop steep yard]
 
+namespace :docs do
+  desc 'Install the mkdocs toolchain pinned in requirements-docs.txt'
+  task :install do
+    sh 'python3 -m pip install --user -r requirements-docs.txt'
+  end
+
+  desc 'Build the mkdocs site into ./site (mirrors the CI Pages build)'
+  task :build do
+    sh 'python3 -m mkdocs build --strict'
+  end
+
+  desc 'Serve the mkdocs site on http://127.0.0.1:8000 with live reload'
+  task :serve do
+    sh 'python3 -m mkdocs serve'
+  end
+end
+
 task default: :test

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -4,7 +4,7 @@
 This is the hand-written, curated reference for every public symbol
 that ships in `assistant` 1.0.0. The source of truth for stability
 labels is
-[`docs/v1/01-api-surface.md`](./v1/01-api-surface.md); the table
+[`docs/v1/01-api-surface.md`](https://github.com/ramongr/assistant/blob/main/docs/v1/01-api-surface.md); the table
 of contents here mirrors it.
 
 Anything not listed on this page is **internal** and may change

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,21 @@
+# Changelog
+
+The full release history is in
+[`CHANGELOG.md`](https://github.com/ramongr/assistant/blob/main/CHANGELOG.md)
+at the repository root, formatted per
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+The same file is what `assistant.gemspec` points to via
+`spec.metadata['changelog_uri']`, so RubyGems shows the identical content
+under the gem's **Changelog** tab.
+
+## How to read it
+
+- `[Unreleased]` collects changes that have merged to `main` but have not
+  been cut into a release tag.
+- Each released version uses an ISO date and groups entries by
+  `### Added` / `### Changed` / `### Deprecated` / `### Removed` /
+  `### Fixed` / `### Security`.
+- `### Changed (Breaking)` callouts mark semver-breaking changes; for
+  the 0.x → 1.x sweep, those are catalogued in
+  [`docs/v1/06-migration-0x-to-1.md`](https://github.com/ramongr/assistant/blob/main/docs/v1/06-migration-0x-to-1.md).

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -72,10 +72,10 @@ method, so an override under the old name is silently bypassed.
 ### Why
 
 Q2 in
-[`docs/v1/07-risks-and-open-questions.md`](./v1/07-risks-and-open-questions.md)
+[`docs/v1/07-risks-and-open-questions.md`](https://github.com/ramongr/assistant/blob/main/docs/v1/07-risks-and-open-questions.md)
 was decided in favour of Option B: the new names read better, match
 standard English, and are easier to grep for. The old names live one
 minor cycle to give downstream services an upgrade window.
 
-See [`docs/v1/02-features.md`](./v1/02-features.md) **M9** for the
+See [`docs/v1/02-features.md`](https://github.com/ramongr/assistant/blob/main/docs/v1/02-features.md) **M9** for the
 implementation plan and acceptance criteria.

--- a/docs/examples/cli-handler.md
+++ b/docs/examples/cli-handler.md
@@ -1,0 +1,11 @@
+# CLI handler
+
+> **Status:** placeholder — ships in
+> [P7](https://github.com/ramongr/assistant/blob/main/docs/v1/08-github-pages.md#p6p12-examples-one-pr-per-example) of
+> the GitHub Pages plan.
+
+An `OptionParser`-driven script whose exit code derives from `#status`.
+
+When the runnable script under `examples/cli_handler/` lands, this
+page will include it verbatim via mkdocs `pymdownx.snippets` so the
+prose stays in lockstep with the code.

--- a/docs/examples/composing-services.md
+++ b/docs/examples/composing-services.md
@@ -1,0 +1,11 @@
+# Composing services
+
+> **Status:** placeholder — ships in
+> [P9](https://github.com/ramongr/assistant/blob/main/docs/v1/08-github-pages.md#p6p12-examples-one-pr-per-example) of
+> the GitHub Pages plan.
+
+An outer service uses `call_service` to chain two inner services with log timeline merging.
+
+When the runnable script under `examples/composing_services/` lands, this
+page will include it verbatim via mkdocs `pymdownx.snippets` so the
+prose stays in lockstep with the code.

--- a/docs/examples/execute-callbacks.md
+++ b/docs/examples/execute-callbacks.md
@@ -1,0 +1,11 @@
+# Execute callbacks
+
+> **Status:** placeholder — ships in
+> [P10](https://github.com/ramongr/assistant/blob/main/docs/v1/08-github-pages.md#p6p12-examples-one-pr-per-example) of
+> the GitHub Pages plan.
+
+`before_execute` audit logger plus an `around_execute` timing wrapper, including failure cases.
+
+When the runnable script under `examples/execute_callbacks/` lands, this
+page will include it verbatim via mkdocs `pymdownx.snippets` so the
+prose stays in lockstep with the code.

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,0 +1,22 @@
+# Examples
+
+> **Status:** gallery scaffolding — each entry below ships with a
+> runnable script under `examples/<slug>/`, a writeup on this site,
+> and a regression test. See
+> [P6–P12 of the GitHub Pages plan](https://github.com/ramongr/assistant/blob/main/docs/v1/08-github-pages.md#p6p12-examples-one-pr-per-example)
+> for the per-example schedule.
+
+| Example | Demonstrates |
+| --- | --- |
+| [Rails service](rails-service.md) | Rails-shaped controller; `case service.run in { result:, status: :ok }`. |
+| [CLI handler](cli-handler.md) | `OptionParser` driving a service; exit code derived from `#status`. |
+| [Sidekiq worker](sidekiq-worker.md) | Worker class that runs a service; idempotent; logs warnings vs errors separately. |
+| [Composing services](composing-services.md) | Outer service uses `call_service` to chain two inner services; log timeline merging. |
+| [Execute callbacks](execute-callbacks.md) | `before_execute` audit logger; `around_execute` timing wrapper; failure cases. |
+| [Instrumentation notifier](instrumentation-notifier.md) | `Assistant.notifier=` wired to a fake `ActiveSupport::Notifications`-shaped sink. |
+| [RBS generator](rbs-generator.md) | Service definition → `bin/assistant-rbs --output sig` → Steep proving per-input return types. |
+
+Each example is intentionally small enough to be read in one sitting.
+Source for every script lives under
+[`examples/`](https://github.com/ramongr/assistant/tree/main/examples)
+in the repository.

--- a/docs/examples/instrumentation-notifier.md
+++ b/docs/examples/instrumentation-notifier.md
@@ -1,0 +1,11 @@
+# Instrumentation notifier
+
+> **Status:** placeholder — ships in
+> [P11](https://github.com/ramongr/assistant/blob/main/docs/v1/08-github-pages.md#p6p12-examples-one-pr-per-example) of
+> the GitHub Pages plan.
+
+`Assistant.notifier=` wired to a fake `ActiveSupport::Notifications`-shaped sink.
+
+When the runnable script under `examples/instrumentation_notifier/` lands, this
+page will include it verbatim via mkdocs `pymdownx.snippets` so the
+prose stays in lockstep with the code.

--- a/docs/examples/rails-service.md
+++ b/docs/examples/rails-service.md
@@ -1,0 +1,11 @@
+# Rails service
+
+> **Status:** placeholder — ships in
+> [P6](https://github.com/ramongr/assistant/blob/main/docs/v1/08-github-pages.md#p6p12-examples-one-pr-per-example) of
+> the GitHub Pages plan.
+
+A Rails-shaped controller calling a service and pattern-matching on the result hash.
+
+When the runnable script under `examples/rails_service/` lands, this
+page will include it verbatim via mkdocs `pymdownx.snippets` so the
+prose stays in lockstep with the code.

--- a/docs/examples/rbs-generator.md
+++ b/docs/examples/rbs-generator.md
@@ -1,0 +1,11 @@
+# RBS generator
+
+> **Status:** placeholder — ships in
+> [P12](https://github.com/ramongr/assistant/blob/main/docs/v1/08-github-pages.md#p6p12-examples-one-pr-per-example) of
+> the GitHub Pages plan.
+
+Service definition → `bin/assistant-rbs --output sig` → Steep proving the per-input return type.
+
+When the runnable script under `examples/rbs_generator/` lands, this
+page will include it verbatim via mkdocs `pymdownx.snippets` so the
+prose stays in lockstep with the code.

--- a/docs/examples/sidekiq-worker.md
+++ b/docs/examples/sidekiq-worker.md
@@ -1,0 +1,11 @@
+# Sidekiq worker
+
+> **Status:** placeholder — ships in
+> [P8](https://github.com/ramongr/assistant/blob/main/docs/v1/08-github-pages.md#p6p12-examples-one-pr-per-example) of
+> the GitHub Pages plan.
+
+A background job that runs a service idempotently, logging warnings vs errors separately.
+
+When the runnable script under `examples/sidekiq_worker/` lands, this
+page will include it verbatim via mkdocs `pymdownx.snippets` so the
+prose stays in lockstep with the code.

--- a/docs/guides/inputs.md
+++ b/docs/guides/inputs.md
@@ -270,7 +270,7 @@ example that snapshots the outer service's inputs into an inner one.
 generated at class-definition time by `Service.input`, which means a
 generic `.rbs` for `Service` can't know that your `CreateUser#email`
 returns `String`. That's R1 in
-[`docs/v1/05-quality-and-tooling.md`](../v1/05-quality-and-tooling.md).
+[`docs/v1/05-quality-and-tooling.md`](https://github.com/ramongr/assistant/blob/main/docs/v1/05-quality-and-tooling.md).
 
 The bundled `assistant-rbs` CLI (M11) closes the gap by emitting
 per-class `.rbs` files. Run it once after editing your services:

--- a/docs/guides/logging-and-results.md
+++ b/docs/guides/logging-and-results.md
@@ -158,7 +158,7 @@ end
 
 > **M12.** `#merge_logs` is keyword-only in 1.0. Passing positional
 > arguments raises `ArgumentError`. The
-> [migration guide](../v1/06-migration-0x-to-1.md) covers the
+> [migration guide](https://github.com/ramongr/assistant/blob/main/docs/v1/06-migration-0x-to-1.md) covers the
 > mechanical rewrite.
 
 ## Inspecting an entry
@@ -193,4 +193,4 @@ service.errors.first.item
   merges inner logs into the outer timeline.
 - [API reference: LogItem](../api-reference.md#assistantlogitem).
 - [API reference: LogList](../api-reference.md#assistantloglist).
-- [Migration guide](../v1/06-migration-0x-to-1.md) for M10 + M12.
+- [Migration guide](https://github.com/ramongr/assistant/blob/main/docs/v1/06-migration-0x-to-1.md) for M10 + M12.

--- a/docs/guides/rbs-and-types.md
+++ b/docs/guides/rbs-and-types.md
@@ -1,0 +1,10 @@
+# RBS and types
+
+> **Status:** placeholder — full content lands in
+> [P4](https://github.com/ramongr/assistant/blob/main/docs/v1/08-github-pages.md) of the GitHub Pages plan. For now,
+> see the [RBS subsection in the Inputs guide](inputs.md#using-assistant-rbs-for-steep-users)
+> and the [Recipe in the 0.x → 1.x migration guide](https://github.com/ramongr/assistant/blob/main/docs/v1/06-migration-0x-to-1.md#recipe-binassistant-rbs-for-steep-users).
+
+This page will cover the `bin/assistant-rbs` per-class generator (M11),
+the R1 metaprogramming limitation that motivates it, and how to wire
+the generated `.rbs` files into a Steep-checked project.

--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -121,7 +121,7 @@ The `if:` predicate is called with the *input's own value*. The
 validator requires the input to be present **and** the predicate to
 be truthy — so the canonical use is "I need this to be present
 *when* some other condition holds". See
-[`inputs.md`](./inputs.md#if--conditional-requirement) for the
+[`inputs.md`](./inputs.md#if-conditional-requirement) for the
 inverse pattern.
 
 ## `LogItem.new` raises in 1.0 (M10)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,62 @@
+# Assistant
+
+**Tiny, dependency-free soft-fail service objects for Ruby.**
+
+[![Gem Version](https://badge.fury.io/rb/assistant.svg)](https://rubygems.org/gems/assistant)
+[![CI](https://github.com/ramongr/assistant/actions/workflows/ci.yml/badge.svg)](https://github.com/ramongr/assistant/actions/workflows/ci.yml)
+
+Assistant lets you write service objects that **never raise for expected
+failures**. A service declares its inputs, validates them, runs its body, and
+returns a uniform result hash that always carries either a value plus
+warnings or a list of errors. Ships with RBS signatures, a 1.0-frozen public
+API, and zero runtime gem dependencies.
+
+## Install
+
+```ruby
+# Gemfile
+gem 'assistant', '~> 1.0'
+```
+
+```sh
+bundle install
+```
+
+Ruby 3.4 or newer is required.
+
+## The 60-second example
+
+```ruby
+require 'assistant'
+
+class CreateUser < Assistant::Service
+  input :email, type: String, required: true
+  input :name,  type: String, default: 'Anonymous'
+
+  def execute
+    log_item_info(source: :create_user, detail: :persisted, message: "saved #{email}")
+    User.create!(email: email, name: name)
+  end
+end
+
+case CreateUser.run(email: 'me@example.com')
+in { result:, status: :ok }
+  result
+in { errors:, status: :with_errors }
+  errors.map(&:item)
+end
+```
+
+## Where to next
+
+- **[Getting started](getting-started.md)** — walk through your first
+  service end-to-end.
+- **[Guides](guides/inputs.md)** — DSL deep-dives, one page per concern.
+- **[API reference](api-reference.md)** — every Frozen symbol, deep-link
+  friendly.
+- **[Examples](examples/index.md)** — runnable patterns (Rails, CLI,
+  Sidekiq, composition, callbacks, instrumentation, RBS).
+- **[Roadmap](roadmap.md)** — what's planned, what shipped.
+- **[Changelog](changelog.md)** — full release history.
+
+Source on [GitHub](https://github.com/ramongr/assistant).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,28 @@
+# Roadmap
+
+The full 1.0 plan lives in
+[`docs/v1/`](https://github.com/ramongr/assistant/tree/main/docs/v1) in
+the repository. Each file below is a focused planning document; the
+index ties them together.
+
+| Doc | What it covers |
+| --- | --- |
+| [`README.md`](https://github.com/ramongr/assistant/blob/main/docs/v1/README.md) | Plan index and reading order. |
+| [`00-overview.md`](https://github.com/ramongr/assistant/blob/main/docs/v1/00-overview.md) | 1.0 goals, non-goals, acceptance criteria. |
+| [`01-api-surface.md`](https://github.com/ramongr/assistant/blob/main/docs/v1/01-api-surface.md) | Frozen vs Experimental symbols, stability labels. |
+| [`02-features.md`](https://github.com/ramongr/assistant/blob/main/docs/v1/02-features.md) | M1–M13 milestones and the promoted M-S* set. |
+| [`03-documentation.md`](https://github.com/ramongr/assistant/blob/main/docs/v1/03-documentation.md) | D1–D5 documentation deliverables. |
+| [`04-release-checklist.md`](https://github.com/ramongr/assistant/blob/main/docs/v1/04-release-checklist.md) | Pre-release, RC, release, and post-release steps. |
+| [`05-quality-and-tooling.md`](https://github.com/ramongr/assistant/blob/main/docs/v1/05-quality-and-tooling.md) | SimpleCov, RuboCop, Steep, CI matrix. |
+| [`06-migration-0x-to-1.md`](https://github.com/ramongr/assistant/blob/main/docs/v1/06-migration-0x-to-1.md) | The three mechanical rewrites required to upgrade. |
+| [`07-risks-and-open-questions.md`](https://github.com/ramongr/assistant/blob/main/docs/v1/07-risks-and-open-questions.md) | Known constraints (e.g. R1 RBS limitation) and resolutions. |
+| [`08-github-pages.md`](https://github.com/ramongr/assistant/blob/main/docs/v1/08-github-pages.md) | The plan for **this site** (parallel deliverable, not a 1.0 gate). |
+
+## Current snapshot
+
+- 1.0 release plumbing is in flight — the gem is at
+  [`1.0.0.rc1`](changelog.md) and the migration recipe is finalised.
+- Every "Must" milestone (M1–M13) and every promoted "Should"
+  (M-S1–M-S4) has shipped to `main`.
+- The mkdocs site you're reading now is P2 of the GitHub Pages plan;
+  later phases land the remaining guide / example content.

--- a/docs/v1/08-github-pages.md
+++ b/docs/v1/08-github-pages.md
@@ -67,26 +67,33 @@ then, and gains an "Online docs" link in a follow-up once Pages is live.
 Goal: every push to `main` deploys the site, even if content is mostly
 placeholder.
 
-- [ ] `mkdocs.yml` at repo root: site name, `theme: name: material`, palette
+- [x] `mkdocs.yml` at repo root: site name, `theme: name: material`, palette
       with light/dark toggle, repo URL + edit-this-page links, navigation
       tree matching the **Site map** table.
-- [ ] `requirements-docs.txt`: pinned `mkdocs`, `mkdocs-material`,
-      `mkdocs-material-extensions`, `mkdocs-mermaid2-plugin`,
-      `pymdown-extensions`.
-- [ ] Placeholder Markdown stubs for every site-map entry that does not
-      yet exist (each carries a one-line "Coming in PR Pn" note).
-- [ ] `.github/workflows/docs.yml`: triggers on push to `main` (paths
-      `docs/**`, `mkdocs.yml`, `requirements-docs.txt`, the workflow
-      itself). Steps: `actions/setup-python@v5`, install requirements,
-      `mkdocs build --strict`, `actions/configure-pages`,
-      `actions/upload-pages-artifact`, `actions/deploy-pages`. Permissions:
-      `pages: write`, `id-token: write`. Concurrency group `pages` with
-      `cancel-in-progress: false`.
+- [x] `requirements-docs.txt`: pinned `mkdocs`, `mkdocs-material`,
+      `mkdocs-material-extensions`, `pymdown-extensions`, plus a
+      `Pygments` floor to dodge the 2.20.0 regression. The
+      `mkdocs-mermaid2-plugin` pin is deferred until P3 actually adds a
+      diagram so we don't ship a JS dependency for placeholders.
+- [x] Placeholder Markdown stubs for every site-map entry that does not
+      yet exist (each carries a one-line "Coming in PR Pn" note):
+      `docs/index.md`, `docs/guides/rbs-and-types.md`,
+      `docs/examples/index.md`, and the seven `docs/examples/*.md`
+      example pages, plus snippet-light `docs/roadmap.md` and
+      `docs/changelog.md` routes.
+- [x] `.github/workflows/docs.yml`: triggers on push to `main` and PR
+      against `main` (paths `docs/**`, `mkdocs.yml`,
+      `requirements-docs.txt`, the workflow itself). Steps:
+      `actions/setup-python@v5`, install requirements,
+      `mkdocs build --strict`, `actions/upload-pages-artifact`,
+      `actions/deploy-pages` (deploy step gated to `push` on `main`).
+      Permissions: `pages: write`, `id-token: write` on the deploy job
+      only. Concurrency group `pages` with `cancel-in-progress: false`.
 - [ ] Enable GitHub Pages source = "GitHub Actions" in repo settings
       (one-time manual step; note in CHANGELOG release-engineering).
-- [ ] `Rakefile` `docs:serve` and `docs:build` tasks that shell out to
-      `python -m mkdocs serve` / `build` after `pip install -r
-      requirements-docs.txt`.
+- [x] `Rakefile` `docs:serve`, `docs:build`, and `docs:install` tasks
+      that shell out to `python3 -m mkdocs serve` / `build` / pip-install
+      the pinned requirements.
 - [ ] Verify the deployed site renders at
       `https://ramongr.github.io/assistant/` with the nav tree intact.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,102 @@
+# mkdocs configuration for the assistant gem docs site.
+# Lives at https://ramongr.github.io/assistant/.
+# See docs/v1/08-github-pages.md for the plan and locked decisions.
+
+site_name: Assistant
+site_description: Tiny, dependency-free soft-fail service objects for Ruby
+site_author: Ramon Rodrigues
+site_url: https://ramongr.github.io/assistant/
+
+repo_name: ramongr/assistant
+repo_url: https://github.com/ramongr/assistant
+edit_uri: edit/main/docs/
+
+docs_dir: docs
+# v1 planning material is /roadmap/-only; everything else ships from docs/.
+# The site build excludes the v1 planning files explicitly so they don't
+# pollute search results.
+exclude_docs: |
+  v1/
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - navigation.tracking
+    - content.code.copy
+    - content.action.edit
+    - content.tabs.link
+    - search.highlight
+    - search.share
+    - search.suggest
+  palette:
+    - media: '(prefers-color-scheme: light)'
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to dark mode
+    - media: '(prefers-color-scheme: dark)'
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to light mode
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets:
+      check_paths: true
+      base_path:
+        - .
+        - docs
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+
+nav:
+  - Home: index.md
+  - Getting started: getting-started.md
+  - Guides:
+      - Inputs: guides/inputs.md
+      - Validation: guides/validation.md
+      - Logging and results: guides/logging-and-results.md
+      - Composing services: guides/composing-services.md
+      - RBS and types: guides/rbs-and-types.md
+  - API reference: api-reference.md
+  - Deprecations: deprecations.md
+  - Examples:
+      - Overview: examples/index.md
+      - Rails service: examples/rails-service.md
+      - CLI handler: examples/cli-handler.md
+      - Sidekiq worker: examples/sidekiq-worker.md
+      - Composing services: examples/composing-services.md
+      - Execute callbacks: examples/execute-callbacks.md
+      - Instrumentation notifier: examples/instrumentation-notifier.md
+      - RBS generator: examples/rbs-generator.md
+  - Roadmap: roadmap.md
+  - Changelog: changelog.md

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,14 @@
+# Pinned toolchain for the mkdocs site under docs/.
+# See docs/v1/08-github-pages.md for the locked stack decisions.
+# Bump these in their own PR so a docs-only change isn't conflated
+# with a toolchain upgrade.
+
+mkdocs==1.6.1
+mkdocs-material==9.5.49
+mkdocs-material-extensions==1.3.1
+pymdown-extensions==10.12
+# Pin Pygments below 2.20: 2.20.0 regresses on HtmlFormatter when
+# pymdownx.highlight passes filename=None (raises AttributeError in
+# html.escape). Fixed upstream after we pinned; keep this floor until
+# pymdown-extensions / mkdocs-material adjust their call sites.
+Pygments==2.19.1


### PR DESCRIPTION
## Scope

Implements **P2** of [`docs/v1/08-github-pages.md`](https://github.com/ramongr/assistant/blob/main/docs/v1/08-github-pages.md) — the mkdocs scaffolding and deploy pipeline for the parallel docs site at `https://ramongr.github.io/assistant/`. The 1.0 tag does **not** depend on Pages going live; this ships on its own track.

## What this PR ships

- **`mkdocs.yml`** at the repo root: Material theme, indigo palette, light/dark toggle, repo-edit links, search, `pymdownx.{highlight,inlinehilite,snippets,superfences,tabbed,details}` enabled, and a nav tree mirroring the locked **Site map** (Home / Getting started / Guides ×5 / API reference / Deprecations / Examples ×8 / Roadmap / Changelog). `docs/v1/` is excluded from the built site via `exclude_docs`.
- **`requirements-docs.txt`**: pinned `mkdocs==1.6.1`, `mkdocs-material==9.5.49`, `mkdocs-material-extensions==1.3.1`, `pymdown-extensions==10.12`, and a `Pygments==2.19.1` floor to dodge the 2.20.0 `HtmlFormatter` regression (`AttributeError: 'NoneType' object has no attribute 'replace'`) that breaks `pymdownx.highlight`. `mkdocs-mermaid2-plugin` is deferred until P3 actually adds a diagram so we don't ship a JS dependency for placeholders.
- **`.github/workflows/docs.yml`**: PRs (and pushes to `main`) build with `mkdocs build --strict`; pushes to `main` additionally deploy via `actions/upload-pages-artifact@v3` + `actions/deploy-pages@v4`. Permissions are minimal (`contents: read` at the workflow level; `pages: write` + `id-token: write` only on the deploy job). Concurrency group `pages` with `cancel-in-progress: false` per Pages best practice.
- **Rake tasks**: `rake docs:install`, `rake docs:build`, `rake docs:serve` so Ruby contributors don't have to remember the Python command.
- **`docs/index.md`** landing page with elevator pitch, install, the 60-second example, and the primary CTAs.
- **Placeholder stubs** for every site-map entry that did not yet exist: `docs/guides/rbs-and-types.md`, `docs/examples/{index,rails-service,cli-handler,sidekiq-worker,composing-services,execute-callbacks,instrumentation-notifier,rbs-generator}.md`, `docs/roadmap.md` (curated table linking to each v1 planning doc), and `docs/changelog.md` (points readers at the canonical `CHANGELOG.md` + RubyGems Changelog tab).
- **Link cleanup**: rewrote `v1/*.md` relative links in `docs/api-reference.md`, `docs/deprecations.md`, `docs/guides/inputs.md`, `docs/guides/logging-and-results.md`, and fixed a stale `#if--conditional-requirement` anchor in `docs/guides/validation.md` so the deployed site doesn't 404 on its own internal links.
- **`.gitignore`**: ignore the generated `/site/` directory.
- **`CHANGELOG.md`**: prepended an `Unreleased` entry under `### Added`.
- **`docs/v1/08-github-pages.md`**: P2 checkboxes flipped to `[x]` (manual Pages-source toggle + post-deploy verification remain open as inherently manual steps).

## Sample output

```
$ /tmp/mkdocs-venv/bin/mkdocs build --strict
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: …/assistant/site
INFO    -  Documentation built in 0.38 seconds
```

Generated `site/` contains: `404.html`, `api-reference/`, `assets/`, `changelog/`, `deprecations/`, `examples/`, `getting-started/`, `guides/`, `index.html`, `roadmap/`, `search/`, `sitemap.xml(.gz)`.

## Verification

\`\`\`
$ bundle exec rake ci
…
265 runs, 701 assertions, 0 failures, 0 errors, 0 skips
Line Coverage: 99.55% (439 / 441)
Branch Coverage: 95.65% (88 / 92)
45 files inspected, no offenses detected
No type error detected. 🧋
yard: 100.00% documented
\`\`\`

## Out of scope (deferred)

- **Manual Pages source toggle**: repo owner has to set Settings → Pages → Source = "GitHub Actions" once after this PR merges. The deploy job will fail loudly until that happens; that is fine and intentionally captured as an open checkbox in P2.
- **First deploy verification** at `https://ramongr.github.io/assistant/` (only possible post-merge).
- **Real content** for the example pages and the standalone `rbs-and-types.md` guide (lands in P4 / P6–P12 per the plan).
- **`mkdocs-mermaid2-plugin`** install (no diagrams shipped yet).