### PR TITLE
chore(docs): record v1.0.0.rc1 release + smoke results

### DIFF
--- a/docs/v1/04-release-checklist.md
+++ b/docs/v1/04-release-checklist.md
@@ -89,11 +89,19 @@ dependency.
 
 ## Pre-release: RC tag
 
-- [ ] Bump `Assistant::VERSION` to `'1.0.0.rc1'` on a release branch.
-- [ ] Push the branch, open the PR, get CI green.
-- [ ] Tag `v1.0.0.rc1`, push the tag — `.github/workflows/release.yml` will
-      build, publish to RubyGems, and create a GitHub Release.
-- [ ] Smoke-test in a brand-new Ruby 3.4 project:
+- [x] Bump `Assistant::VERSION` to `'1.0.0.rc1'` on a release branch.
+      Shipped in PR #176 (`b599b26`).
+- [x] Push the branch, open the PR, get CI green. PR #176 squash-merged
+      to `main` (`6aa9947`) with all 7 CI checks green.
+- [x] Tag `v1.0.0.rc1`, push the tag — `.github/workflows/release.yml` will
+      build, publish to RubyGems, and create a GitHub Release. Tag pushed
+      from `main` at `0d2ee42`; release run
+      [27554209442](https://github.com/ramongr/assistant/actions/runs/27554209442)
+      succeeded (tests pre-publish, build gem, push to RubyGems via OIDC,
+      create GitHub Release with the gem artifact). Release page was
+      flipped to `prerelease: true` manually since `softprops/action-gh-release`
+      doesn't auto-detect Ruby's `.rcN` suffix.
+- [x] Smoke-test in a brand-new Ruby 3.4 project:
   ```sh
   mkdir /tmp/assistant-rc1 && cd /tmp/assistant-rc1
   bundle init
@@ -101,6 +109,12 @@ dependency.
   ruby -r assistant -e 'class S < Assistant::Service; def execute = :ok; end; p S.run'
   bundle exec assistant-rbs . --output sig    # verify CLI works
   ```
+  All commands exited 0 on Ruby 3.4.9: `S.run` returned
+  `{result: :ok, status: :ok, warnings: []}`; `Assistant::VERSION` resolved
+  to `"1.0.0.rc1"`; `assistant-rbs` produced no output on the empty source
+  tree (exit 0). Verified `runtime_dependencies == []` on the installed
+  gem, plus `documentation_uri` / `bug_tracker_uri` / `summary` match the
+  polished gemspec from PR #172.
 - [ ] **No fixed soak period** — tag `v1.0.0` as soon as the smoke-test
       passes and CI on the RC tag is green. If bugs surface post-RC, cut
       additional `rcN` tags until clean.


### PR DESCRIPTION
## Scope

Flips the four \`Pre-release: RC tag\` checkboxes in
[\`docs/v1/04-release-checklist.md\`](docs/v1/04-release-checklist.md)
to \`[x]\` now that the RC tag has been pushed and smoke-tested. Pure
doc update.

## What ships

- **Version bump**: shipped in PR #176 (\`b599b26\`).
- **RC tag**: \`v1.0.0.rc1\` pushed from \`main\` at \`0d2ee42\`. Release
  run [27554209442](https://github.com/ramongr/assistant/actions/runs/27554209442)
  succeeded end-to-end — tests pre-publish, gem build, push to RubyGems
  via OIDC trusted publishing, GitHub Release with the gem artifact.
- **Release page**: flipped to \`prerelease: true\` manually because
  \`softprops/action-gh-release\` doesn't auto-detect Ruby's \`.rcN\`
  suffix.
- **Smoke**: ran the recipe verbatim in a fresh \`/tmp/assistant-rc1\`
  on Ruby 3.4.9. All commands exited 0; \`runtime_dependencies\` confirmed
  empty on the installed gem.

## Sample output

\`\`\`text
$ bundle add assistant --version 1.0.0.rc1
Fetching assistant 1.0.0.rc1
Installing assistant 1.0.0.rc1

\$ ruby -r assistant -e 'class S < Assistant::Service; def execute = :ok; end; p S.run'
{result: :ok, status: :ok, warnings: []}

\$ ruby -r assistant -e 'p Assistant::VERSION'
\"1.0.0.rc1\"

\$ bundle exec ruby -e 'spec = Gem::Specification.find_by_name(\"assistant\"); p spec.runtime_dependencies'
[]
\`\`\`

## Verification

\`\`\`text
\$ bundle exec rake ci
265 runs, 701 assertions, 0 failures, 0 errors, 0 skips
Line Coverage: 99.55% (439 / 441)
Branch Coverage: 95.65% (88 / 92)
45 files inspected, no offenses detected
No type error detected.
yard: 100.00% documented
\`\`\`

## Out of scope

- The \"No fixed soak period\" bullet stays \`[ ]\` until the \`v1.0.0\`
  cut completes.
- The \`## Release: 1.0.0 tag\` and post-release housekeeping blocks
  remain open for the v1.0.0 cut PR.