### PR TITLE
docs: redesign the GitHub Pages landing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **GitHub Pages — home page redesign**: replace the bare
+  [`docs/index.md`](docs/index.md) landing with a richer page —
+  primary/secondary CTA buttons (built on just-the-docs's `.btn`
+  utilities), a three-column "Why Assistant?" value-prop strip
+  (soft-fail / zero deps / typed + Steep-ready), a Mermaid
+  lifecycle teaser ("How a service flows"), the install + 60-second
+  example blocks, and a "Where to next" navigation grid that
+  surfaces every top-level page (including Deprecations).
+
 - **GitHub Pages — examples gallery rewrites**: replace the seven
   `docs/examples/<slug>.md` P6–P12 placeholders with self-contained,
   callout-sized code patterns covering Rails controllers, CLI

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,17 +6,51 @@ permalink: /
 ---
 
 # Assistant
+{: .fs-9 .fw-700 .mb-1 }
 
 **Tiny, dependency-free soft-fail service objects for Ruby.**
+{: .fs-6 .fw-300 .text-grey-dk-100 }
 
 [![Gem Version](https://badge.fury.io/rb/assistant.svg)](https://rubygems.org/gems/assistant)
 [![CI](https://github.com/ramongr/assistant/actions/workflows/ci.yml/badge.svg)](https://github.com/ramongr/assistant/actions/workflows/ci.yml)
+[![Docs](https://github.com/ramongr/assistant/actions/workflows/docs.yml/badge.svg)](https://github.com/ramongr/assistant/actions/workflows/docs.yml)
 
-Assistant lets you write service objects that **never raise for expected
-failures**. A service declares its inputs, validates them, runs its body, and
-returns a uniform result hash that always carries either a value plus
-warnings or a list of errors. Ships with RBS signatures, a 1.0-frozen public
-API, and zero runtime gem dependencies.
+A service declares its inputs, validates them, runs its body, and returns a
+uniform result hash that always carries either a value plus warnings, or a
+list of errors. Frozen 1.0 public API. RBS signatures ship in `sig/`.
+**Zero runtime gem dependencies.**
+
+[Get started in 60 seconds](getting-started.md){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[Browse the guides](guides/){: .btn .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[View on GitHub](https://github.com/ramongr/assistant){: .btn .fs-5 .mb-4 .mb-md-0 }
+
+---
+
+## Why Assistant?
+
+| Soft-fail by default | Zero runtime deps | Typed and Steep-ready |
+|:---|:---|:---|
+| Expected failures become structured `LogItem` errors with a `:status`, not raised exceptions. Callers pattern-match on the result. | The gemspec declares zero runtime dependencies, and CI enforces it on every push. Drop-in for any Ruby 3.4+ project. | Hand-curated RBS sidecars for the public API plus the `assistant-rbs` generator for your own services. Steep-checked in CI. |
+
+---
+
+## How a service flows
+
+```mermaid
+flowchart LR
+    Run([Service.run]) --> Validate{Inputs +<br/>#validate}
+    Validate -- errors --> Failed[status: :with_errors]
+    Validate -- clean --> Execute[#execute]
+    Execute -- warnings --> Warns[status: :with_warnings]
+    Execute -- clean --> Ok[status: :ok]
+    Execute -- errors --> Failed
+```
+
+Validation runs first; `#execute` is skipped entirely when errors are already
+on the log. Warnings never short-circuit anything — they ride along on the
+result so the caller can decide what to surface.
+
+---
 
 ## Install
 
@@ -38,6 +72,8 @@ gem 'assistant', '~> 1.0'
 ```
 
 Ruby 3.4 or newer is required.
+
+---
 
 ## The 60-second example
 
@@ -62,16 +98,28 @@ in { errors:, status: :with_errors }
 end
 ```
 
+The same call returns `:with_warnings` if `#execute` logged any warnings, and
+`:with_errors` (without invoking `#execute`) if the inputs failed validation.
+
+[Walk through this example end-to-end](getting-started.md){: .btn .btn-outline .fs-4 }
+
+---
+
 ## Where to next
 
-- **[Getting started](getting-started.md)** — walk through your first
-  service end-to-end.
-- **[Guides](guides/inputs.md)** — DSL deep-dives, one page per concern.
-- **[API reference](api-reference.md)** — every Frozen symbol, deep-link
-  friendly.
-- **[Examples](examples/index.md)** — runnable patterns (Rails, CLI,
-  Sidekiq, composition, callbacks, instrumentation, RBS).
-- **[Roadmap](roadmap.md)** — what's planned, what shipped.
-- **[Changelog](changelog.md)** — full release history.
+| Page | What you'll find |
+|:---|:---|
+| [Getting started](getting-started.md) | Install, your first service, consuming a result. |
+| [Guides](guides/) | DSL deep-dives — inputs, validation, logging, composition, RBS. |
+| [API reference](api-reference.md) | Every Frozen symbol in 1.0, deep-link friendly. |
+| [Examples](examples/) | Wiring patterns — Rails, CLI, Sidekiq, callbacks, notifier, RBS. |
+| [Roadmap](roadmap.md) | What's planned, what shipped, parallel deliverables. |
+| [Changelog](changelog.md) | Release history and migration notes. |
+| [Deprecations](deprecations.md) | What's flagged for removal in 2.0. |
 
-Source on [GitHub](https://github.com/ramongr/assistant).
+---
+
+Source on [GitHub](https://github.com/ramongr/assistant) · Released under the
+[MIT License](https://github.com/ramongr/assistant/blob/main/LICENSE.txt) ·
+Contributions welcome — see
+[CONTRIBUTING.md](https://github.com/ramongr/assistant/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
## Scope

The site landing at <https://ramongr.github.io/assistant/> was bare
prose + a flat bullet list. This PR redesigns it so a first-time
visitor reads in one glance: what Assistant is, why they'd pick it,
how a service flows, how to install, and where to click next.

> **Stacked on #182, #183, #184.** Uses the callouts / copy-button /
> Mermaid loader from #182 and the Mermaid wiring exercised by #183.
> If any earlier PR lands first, the rebase here is a no-op merge.

## What ships

[\`docs/index.md\`](docs/index.md):

* **CTA buttons** built on just-the-docs's \`.btn\` / \`.btn-primary\` /
  \`.btn-outline\` utility classes (Get started, Browse the guides,
  View on GitHub, then a secondary CTA under the example).
* **\"Why Assistant?\"** 3-column value-prop table — soft-fail by
  default / zero runtime deps / typed + Steep-ready.
* **\"How a service flows\"** Mermaid lifecycle diagram (\`Service.run\`
  → validate → execute → result-status decision) plus a one-paragraph
  prose caveat explaining the skip-on-errors rule.
* Install + 60-second example blocks kept but separated by horizontal
  rules so each section breathes.
* **\"Where to next\"** switches from a bullet list to a 2-column
  navigation grid covering every top-level page, including the
  previously-orphaned Deprecations page.
* Footer line acknowledging the MIT license + contributing link.

No new build deps or config: just markdown + kramdown attribute
syntax (\`{: .btn .btn-primary }\`) on top of the polish bundle from
#182.

## Verification

\`\`\`text
$ bundle exec jekyll build --strict_front_matter --baseurl '/assistant'
                    done in 0.426 seconds.

$ grep -c 'btn btn-primary' _site/index.html
1
$ grep -c 'language-mermaid' _site/index.html
2   # diagram block + Mermaid loader script
$ grep -c 'Why Assistant' _site/index.html
1
$ grep -c 'How a service flows' _site/index.html
1

$ bundle exec rake ci
265 runs, 701 assertions, 0 failures, 0 errors, 0 skips
Line Coverage: 99.55% (439 / 441)
Branch Coverage: 95.65% (88 / 92)
45 files inspected, no offenses detected
No type error detected.
yard: 100.00% documented
\`\`\`

## Out of scope

* A custom \`_layouts/home.html\` override (the current \`layout: home\`
  + richer markdown is enough for now).
* Theme work beyond what's already shipped in #182 (custom CSS,
  brand-colored heading, etc.).
* Wider site IA changes; \"Where to next\" mirrors the existing nav.