### PR TITLE
fix(docs): apply just-the-docs default layout to every page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **GitHub Pages — restore default layout on every internal page**:
+  add a `defaults:` block to [`_config.yml`](_config.yml) that applies
+  just-the-docs's `layout: default` to every page that doesn't
+  declare its own layout. Before this fix, only the homepage
+  (`layout: home`) rendered with the full chrome — every other page
+  (Getting started, Guides, API reference, Examples, Roadmap,
+  Changelog, Deprecations and all their children) was emitted as a
+  raw `<h1>…</h1>` body fragment with no sidebar, header, search
+  input, sub-nav, copy buttons, dark-mode toggle, footer, or
+  baseurl-aware navigation. Latent since PR #180; the homepage
+  redesign in PR #185 made the contrast visible.
+
 ### Added
 
 - **GitHub Pages — home page redesign**: replace the bare

--- a/_config.yml
+++ b/_config.yml
@@ -93,6 +93,18 @@ kramdown:
   input: GFM
   hard_wrap: false
 
+# Apply just-the-docs's `default` layout to every page that doesn't
+# declare its own (the homepage uses `layout: home`, which is also a
+# just-the-docs layout). Without this defaults block, pages with no
+# `layout:` front matter render as raw <h1>... HTML with no sidebar,
+# header, search, or footer — every internal page in the site looks
+# unstyled and links don't work.
+defaults:
+  - scope:
+      path: ""
+    values:
+      layout: default
+
 # Files Jekyll should ignore. Paths are relative to `source:` (docs/),
 # so `v1` skips docs/v1/ — the v1 planning corpus authored for GitHub's
 # Markdown renderer (relative links into ../ and across plan files). It


### PR DESCRIPTION
## Scope

Fixes the regression you spotted: every internal page on
<https://ramongr.github.io/assistant/> was missing buttons,
sub-nav, search, copy buttons, and dark-mode toggle. Only the
homepage rendered with the full chrome.

## Root cause

\`_config.yml\` had no \`defaults:\` block, so Jekyll applied a layout
only to pages that explicitly declare one. The homepage uses
\`layout: home\`; every other page (Getting started, all Guides, API
reference, all Examples, Roadmap, Changelog, Deprecations) had no
\`layout:\` in its front matter and was emitted as a naked
\`<h1>...</h1>\` body fragment — no \`<html>\`, no sidebar, no header,
no JS, no CSS.

just-the-docs ships \`_layouts/default.html\` but does not register it
as a Jekyll-level default. The canonical config requires:

\`\`\`yaml
defaults:
  - scope:
      path: \"\"
    values:
      layout: default
\`\`\`

Latent since PR #180 (the original Jekyll migration). PR #185 (home
redesign) made the contrast jarring because the landing now shows
how the rest of the site *should* look.

## What ships

* [\`_config.yml\`](_config.yml) — add the \`defaults:\` block.
* [\`CHANGELOG.md\`](CHANGELOG.md) — \`### Fixed\` entry.

No new deps, no other content changes.

## Verification

Before vs after \`bundle exec jekyll build --strict_front_matter --baseurl '/assistant'\`:

| Page | Before | After |
| --- | ---: | ---: |
| \`/\` | 24,782 B | 24,782 B (unchanged) |
| \`/getting-started.html\` | 12,166 B | 28,104 B |
| \`/guides/\` | 2,112 B | 17,736 B |
| \`/examples/\` | 2,798 B | 18,518 B |
| \`/examples/rails-service.html\` | 4,346 B | 20,201 B |
| \`/roadmap.html\` | 3,657 B | 18,837 B |
| \`/changelog.html\` | 1,775 B | 17,166 B |
| \`/deprecations.html\` | 6,088 B | 22,253 B |

Each formerly-broken page now ships:

* \`<html>\`/\`<head>\`/\`<body>\` wrapper.
* The full \`.side-bar\` with logo, nav-list, and Guides + Examples
  sub-nav expander buttons.
* Top-bar with search input and aux-nav (View on GitHub, RubyGems).
* The copy-code buttons, dark-mode toggle, Mermaid loader, and
  callouts from PR #182.
* The home redesign's CTA buttons render unchanged.

\`\`\`text
$ bundle exec rake test
265 runs, 701 assertions, 0 failures
Line Coverage: 99.55%
Branch Coverage: 95.65%
\`\`\`

## Out of scope

* The visual polish bundle from #182 is unchanged; this is purely a
  layout-defaults fix.
* No content changes on any page.