### PR TITLE
fix(docs): use real U+2026 in search placeholder

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -111,7 +111,7 @@
       search: {
         maxAge: 86400000,
         paths: 'auto',
-        placeholder: 'Search the docs &hellip;',
+        placeholder: 'Search the docs …',
         noData: 'No results.',
         depth: 3,
         hideOtherSidebarContent: false

--- a/docs/index.html
+++ b/docs/index.html
@@ -111,7 +111,7 @@
       search: {
         maxAge: 86400000,
         paths: 'auto',
-        placeholder: 'Search the docs &hellip;',
+        placeholder: 'Search the docs …',
         noData: 'No results.',
         depth: 3,
         hideOtherSidebarContent: false


### PR DESCRIPTION
## Scope

Tiny rendering bug in the Docsify search input introduced in #187.

## Symptom

The search box in the sidebar shows the literal 7-character sequence `&hellip;` instead of an ellipsis:

> Search the docs **&hellip;**

## Cause

`docs/index.html` configures the search plugin with:

\`\`\`js
search: {
  placeholder: 'Search the docs &hellip;',
  ...
}
\`\`\`

Docsify's search plugin reads that string and sets it as the `<input>`'s `placeholder` attribute via `element.setAttribute(...)` / property assignment. Browsers do **not** decode HTML entities in attribute values set from JS — only when the HTML is parsed from markup. So the entity is rendered verbatim.

## Fix

Use the actual U+2026 (`…`) character in the JS string. Applied to `docs/index.html` and resynced into `docs/404.html`.

The other entity in the file (`<div id=\"app\">Loading documentation&hellip;</div>`) is fine — that one is parsed from real HTML markup, so the browser decodes it normally.

## Verification

\`\`\`
$ bundle exec rake test
265 runs, 701 assertions, 0 failures, 0 errors, 0 skips

$ bundle exec rubocop
45 files inspected, no offenses detected

$ bundle exec steep check --jobs=1
No type error detected. 🍵
\`\`\`