### PR TITLE
fix(docs): darken light-mode accent to #2f4f5a for WCAG AAA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **GitHub Pages — light-mode accent passes WCAG AAA**: the
+  previous light-mode primary accent `#4d7c8a` Steel Teal cleared
+  WCAG AA-large (3:1) but only reached 4.07:1 on the `#f4f2f3`
+  background, just shy of AA-normal (4.5:1) for body-text links.
+  Introduced `#2f4f5a` Steel Teal Dark as a derived shade — same
+  hue family, 7.87:1 contrast on `#f4f2f3`, comfortably AAA.
+  Replaced the light-theme `accent`, `codeTypeColor`,
+  Docsify `themeColor`, inline `--theme-color`, and the
+  `<meta name="theme-color">` mobile address-bar color. Dark mode
+  is untouched — `#4d7c8a` stays as the dark-theme highlight and
+  the brand-asset color (logo, OG card).
+
 - **GitHub Pages — render Mermaid diagrams**: the
   `docsify-mermaid@2` plugin was loaded from the package root
   (`//cdn.jsdelivr.net/npm/docsify-mermaid@2`), which jsDelivr

--- a/docs/404.html
+++ b/docs/404.html
@@ -8,7 +8,7 @@
   <title>Assistant &mdash; tiny, dependency-free soft-fail service objects for Ruby</title>
   <meta name="description"
         content="Assistant is a tiny, dependency-free Ruby gem for soft-fail service objects with a uniform result shape, structured log items, and first-class RBS/Steep support.">
-  <meta name="theme-color" content="#4d7c8a">
+  <meta name="theme-color" content="#2f4f5a">
 
   <link rel="icon" type="image/svg+xml" href="/assistant/_media/home-logo.svg">
   <link rel="icon" type="image/png" sizes="32x32" href="/assistant/_media/favicon.png">
@@ -38,13 +38,15 @@
   <style>
     :root {
       /* Brand palette
-         #22223b — Space Cadet   (dark text / dark bg)
-         #a07178 — Rose Taupe    (secondary accent / success)
-         #4d7c8a — Steel Teal    (primary accent / links in light mode)
-         #f4f2f3 — Cultured      (light background)
-         #ffd166 — Naples Yellow (primary accent in dark mode;
-                                  light-mode highlight) */
-      --theme-color: #4d7c8a;
+         #22223b — Space Cadet      (dark text / dark bg)
+         #a07178 — Rose Taupe       (secondary accent / success)
+         #4d7c8a — Steel Teal       (dark-mode highlight; brand asset color)
+         #2f4f5a — Steel Teal Dark  (light-mode links / theme color —
+                                     7.87:1 contrast on #f4f2f3, AAA)
+         #f4f2f3 — Cultured         (light background)
+         #ffd166 — Naples Yellow    (primary accent in dark mode;
+                                     light-mode highlight) */
+      --theme-color: #2f4f5a;
     }
     .app-name-link img { width: 28px; height: 28px; }
     .sidebar-toggle { background-color: transparent; }
@@ -101,7 +103,7 @@
       relativePath: true,
       notFoundPage: true,
       executeScript: true,
-      themeColor: '#4d7c8a',
+      themeColor: '#2f4f5a',
       // Hash-routed by default (`/assistant/#/getting-started`). A
       // history-mode experiment was tried but every clean URL like
       // `/assistant/getting-started` returned HTTP 404 on GitHub Pages — Pages
@@ -145,7 +147,7 @@
           coverBackground: 'linear-gradient(to left bottom, #22223b 0%, #ffd166 100%)'
         },
         light: {
-          accent: '#4d7c8a',
+          accent: '#2f4f5a',
           toggleBackground: '#f4f2f3',
           background: '#f4f2f3',
           textColor: '#22223b',
@@ -155,7 +157,7 @@
           blockQuoteColor: '#a07178',
           highlightColor: '#ffd166',
           sidebarSublink: '#22223b',
-          codeTypeColor: '#4d7c8a',
+          codeTypeColor: '#2f4f5a',
           coverBackground: 'linear-gradient(to left bottom, #f4f2f3 0%, #a07178 100%)'
         }
       },

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,7 +8,7 @@
   <title>Assistant &mdash; tiny, dependency-free soft-fail service objects for Ruby</title>
   <meta name="description"
         content="Assistant is a tiny, dependency-free Ruby gem for soft-fail service objects with a uniform result shape, structured log items, and first-class RBS/Steep support.">
-  <meta name="theme-color" content="#4d7c8a">
+  <meta name="theme-color" content="#2f4f5a">
 
   <link rel="icon" type="image/svg+xml" href="/assistant/_media/home-logo.svg">
   <link rel="icon" type="image/png" sizes="32x32" href="/assistant/_media/favicon.png">
@@ -38,13 +38,15 @@
   <style>
     :root {
       /* Brand palette
-         #22223b — Space Cadet   (dark text / dark bg)
-         #a07178 — Rose Taupe    (secondary accent / success)
-         #4d7c8a — Steel Teal    (primary accent / links in light mode)
-         #f4f2f3 — Cultured      (light background)
-         #ffd166 — Naples Yellow (primary accent in dark mode;
-                                  light-mode highlight) */
-      --theme-color: #4d7c8a;
+         #22223b — Space Cadet      (dark text / dark bg)
+         #a07178 — Rose Taupe       (secondary accent / success)
+         #4d7c8a — Steel Teal       (dark-mode highlight; brand asset color)
+         #2f4f5a — Steel Teal Dark  (light-mode links / theme color —
+                                     7.87:1 contrast on #f4f2f3, AAA)
+         #f4f2f3 — Cultured         (light background)
+         #ffd166 — Naples Yellow    (primary accent in dark mode;
+                                     light-mode highlight) */
+      --theme-color: #2f4f5a;
     }
     .app-name-link img { width: 28px; height: 28px; }
     .sidebar-toggle { background-color: transparent; }
@@ -101,7 +103,7 @@
       relativePath: true,
       notFoundPage: true,
       executeScript: true,
-      themeColor: '#4d7c8a',
+      themeColor: '#2f4f5a',
       // Hash-routed by default (`/assistant/#/getting-started`). A
       // history-mode experiment was tried but every clean URL like
       // `/assistant/getting-started` returned HTTP 404 on GitHub Pages — Pages
@@ -145,7 +147,7 @@
           coverBackground: 'linear-gradient(to left bottom, #22223b 0%, #ffd166 100%)'
         },
         light: {
-          accent: '#4d7c8a',
+          accent: '#2f4f5a',
           toggleBackground: '#f4f2f3',
           background: '#f4f2f3',
           textColor: '#22223b',
@@ -155,7 +157,7 @@
           blockQuoteColor: '#a07178',
           highlightColor: '#ffd166',
           sidebarSublink: '#22223b',
-          codeTypeColor: '#4d7c8a',
+          codeTypeColor: '#2f4f5a',
           coverBackground: 'linear-gradient(to left bottom, #f4f2f3 0%, #a07178 100%)'
         }
       },


### PR DESCRIPTION
## Scope

Follow-up to #190. Docs-only. No library code touched.

## Problem

The light-mode primary accent introduced in #190 — `#4d7c8a` Steel
Teal — computed to **4.07:1** contrast on the `#f4f2f3` Cultured
background. WCAG thresholds:

| WCAG level | Min ratio for normal text | `#4d7c8a` |
|---|---|---|
| AA-large (≥18pt or ≥14pt bold) | 3:1   | passes |
| AA-normal                       | 4.5:1 | **fails by 0.43** |
| AAA-normal                      | 7:1   | fails |

Because Docsify renders sidebar entries, search results, and inline
links as normal-weight body text, the accent was effectively
sub-AA. Visibly thin against the near-white background and would
flag in any accessibility audit (axe, Lighthouse, etc.).

## Fix

Introduce `#2f4f5a` **Steel Teal Dark** as a derived shade — same
hue family, deeper luminance — at **7.87:1** contrast on `#f4f2f3`.
Comfortably AAA with headroom for older displays, ambient light,
and mild vision issues.

| Surface | Before | After |
|---|---|---|
| Light theme `accent` (links, buttons, theme tints) | `#4d7c8a` | `#2f4f5a` |
| Light theme `codeTypeColor` (inline `<code>` tags) | `#4d7c8a` | `#2f4f5a` |
| Docsify `themeColor` (initial paint, scrollbar) | `#4d7c8a` | `#2f4f5a` |
| Inline CSS `--theme-color` variable | `#4d7c8a` | `#2f4f5a` |
| `<meta name=\"theme-color\">` (mobile address bar) | `#4d7c8a` | `#2f4f5a` |

The mobile address-bar / CSS theme color shifts to the new shade
because `defaultTheme: 'light'` — the first paint is always light
mode.

## What stays untouched

- **Dark theme.** The dark-mode `highlightColor` and `codeTypeColor`
  remain `#4d7c8a`. On `#22223b` the teal computes to 3.3:1 — fine
  for AA-large (sidebar highlights and inline-code badges, both
  rendered larger or bolder than body text).
- **Brand assets.** `home-logo.svg` and the dark-theme cover
  gradient keep `#4d7c8a` as the brand-asset Steel Teal.
- **`#a07178` Rose Taupe** stays as the `blockQuoteColor` in both
  themes.

The site palette is now **6 colors**: the 5 Coolors brand colors
plus one accessibility-derived dark variant scoped to the
light-mode accent surface. The CSS palette comment in
`docs/index.html` documents this.

## Files changed

- \`docs/index.html\` (+12 / -10) + verbatim mirror \`docs/404.html\`
- \`CHANGELOG.md\` — one new entry under \`[Unreleased]\` \`### Fixed\`

## Verification

\`\`\`
\$ bundle exec rake test
265 runs, 701 assertions, 0 failures, 0 errors, 0 skips
Line Coverage: 99.55% (439 / 441)
Branch Coverage: 95.65% (88 / 92)

\$ bundle exec rubocop
45 files inspected, no offenses detected

\$ bundle exec steep check --jobs=1
No type error detected.
\`\`\`

Contrast computation method: standard WCAG 2.1 relative-luminance
formula on linearized sRGB values. `#2f4f5a` luminance ≈ 0.069;
`#f4f2f3` luminance ≈ 0.890; ratio = (0.890 + 0.05) / (0.069 + 0.05)
≈ 7.87:1.

## Out of scope

- Dark-mode accent contrast tuning (separate concern; current 3.3:1
  passes AA-large for the surfaces it's applied to)
- Repo card regeneration (still outstanding from #188 / #190)