### PR TITLE
fix(docs): light-mode inline code is readable (drop #ffd166 highlightColor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **GitHub Pages — light-mode inline `code` is readable**: the
+  light theme passed `highlightColor: '#ffd166'` Naples Yellow to
+  docsify-darklight-theme. That property controls the **text color
+  of inline `<code>` tags** in markdown (the plugin's CSS sets
+  `.markdown-section code { color: var(--highlightColor) }`), which
+  renders on the `#ffffff` code background at **1.43:1** contrast —
+  essentially invisible. Every inline `code` snippet across the
+  docs site was unreadable in light mode. Swapped to `#2f4f5a`
+  Steel Teal Dark (matching the link accent), giving **8.30:1** on
+  white — comfortably AAA. Dark mode is unchanged; `#ffd166`
+  remains the dark-theme primary accent (12:1 on `#22223b`) and
+  the dark-cover gradient endpoint. Naples Yellow is no longer
+  referenced anywhere in the light-theme palette.
+
 - **GitHub Pages — light-mode accent passes WCAG AAA**: the
   previous light-mode primary accent `#4d7c8a` Steel Teal cleared
   WCAG AA-large (3:1) but only reached 4.07:1 on the `#f4f2f3`

--- a/docs/404.html
+++ b/docs/404.html
@@ -41,11 +41,11 @@
          #22223b — Space Cadet      (dark text / dark bg)
          #a07178 — Rose Taupe       (secondary accent / success)
          #4d7c8a — Steel Teal       (dark-mode highlight; brand asset color)
-         #2f4f5a — Steel Teal Dark  (light-mode links / theme color —
-                                     7.87:1 contrast on #f4f2f3, AAA)
+         #2f4f5a — Steel Teal Dark  (light-mode links / inline code /
+                                     theme color — 7.87:1 on #f4f2f3,
+                                     8.30:1 on #ffffff, both AAA)
          #f4f2f3 — Cultured         (light background)
-         #ffd166 — Naples Yellow    (primary accent in dark mode;
-                                     light-mode highlight) */
+         #ffd166 — Naples Yellow    (primary accent in dark mode only) */
       --theme-color: #2f4f5a;
     }
     .app-name-link img { width: 28px; height: 28px; }
@@ -155,7 +155,7 @@
           codeBackgroundColor: '#ffffff',
           borderColor: 'rgba(34,34,59,0.12)',
           blockQuoteColor: '#a07178',
-          highlightColor: '#ffd166',
+          highlightColor: '#2f4f5a',
           sidebarSublink: '#22223b',
           codeTypeColor: '#2f4f5a',
           coverBackground: 'linear-gradient(to left bottom, #f4f2f3 0%, #a07178 100%)'

--- a/docs/index.html
+++ b/docs/index.html
@@ -41,11 +41,11 @@
          #22223b — Space Cadet      (dark text / dark bg)
          #a07178 — Rose Taupe       (secondary accent / success)
          #4d7c8a — Steel Teal       (dark-mode highlight; brand asset color)
-         #2f4f5a — Steel Teal Dark  (light-mode links / theme color —
-                                     7.87:1 contrast on #f4f2f3, AAA)
+         #2f4f5a — Steel Teal Dark  (light-mode links / inline code /
+                                     theme color — 7.87:1 on #f4f2f3,
+                                     8.30:1 on #ffffff, both AAA)
          #f4f2f3 — Cultured         (light background)
-         #ffd166 — Naples Yellow    (primary accent in dark mode;
-                                     light-mode highlight) */
+         #ffd166 — Naples Yellow    (primary accent in dark mode only) */
       --theme-color: #2f4f5a;
     }
     .app-name-link img { width: 28px; height: 28px; }
@@ -155,7 +155,7 @@
           codeBackgroundColor: '#ffffff',
           borderColor: 'rgba(34,34,59,0.12)',
           blockQuoteColor: '#a07178',
-          highlightColor: '#ffd166',
+          highlightColor: '#2f4f5a',
           sidebarSublink: '#22223b',
           codeTypeColor: '#2f4f5a',
           coverBackground: 'linear-gradient(to left bottom, #f4f2f3 0%, #a07178 100%)'


### PR DESCRIPTION
## Scope

Follow-up to #190 and #191. Docs-only. No library code touched.

## Problem

In #190 I set the light theme's `highlightColor: '#ffd166'` thinking
that property controlled the active-sidebar / search-match
highlights. That was wrong. In the docsify-darklight-theme plugin's
CSS, `highlightColor` is bound to:

\`\`\`css
.markdown-section code {
  color: var(--highlightColor);
  font-weight: 700;
  background-color: var(--codeBackgroundColor);
  ...
}
\`\`\`

That is, **`highlightColor` is the text color of inline `<code>` tags**
in markdown. The light theme's `codeBackgroundColor` is `#ffffff`
(pure white). So:

- `#ffd166` Naples Yellow on `#ffffff` = **1.43:1 contrast**
- WCAG AA-normal minimum: 4.5:1
- WCAG AA-large minimum: 3:1

The result: every inline `` `code` `` snippet across the entire docs
site was *essentially invisible* in light mode — pale yellow on
white. There are inline `code` references on nearly every page
(method names, type signatures, file paths, gem names, CLI flags).

## Fix

Swap the light-theme `highlightColor` to `#2f4f5a` Steel Teal Dark
— the same shade introduced in #191 as the link accent.

- `#2f4f5a` on `#ffffff` = **8.30:1 contrast** (comfortably AAA)
- Inline code and links now share the brand accent color, which is
  the convention on Tailwind, Vue, and most other Docsify-themed
  doc sites
- Code is still visually distinguishable from links — it has its
  own background pill, monospace font, and bolder weight (`700`
  vs `600` for links)

## What stays untouched

- **Dark theme.** The dark theme's `highlightColor` stays at
  `#4d7c8a` Steel Teal — that's a separate, pre-existing value
  that gives ~5.6:1 contrast on the dark `codeBackgroundColor:
  '#2c2c4a'`, which is fine.
- **Dark-mode primary accent.** `#ffd166` is still the
  dark-theme `accent` color (12:1 on `#22223b` — no contrast
  issue) and still anchors the dark-mode cover gradient. Naples
  Yellow is now scoped to **dark-mode surfaces only** — zero
  references in the light palette.
- **Brand assets.** `home-logo.svg`, OG card — unchanged.

The CSS palette comment in `docs/index.html` is updated to reflect
that `#ffd166` is dark-mode only, and that `#2f4f5a` now drives
light-mode links, inline code, and the theme color.

## Files changed

- \`docs/index.html\` (+5 / -5) + verbatim mirror \`docs/404.html\`
- \`CHANGELOG.md\` — one new entry under \`[Unreleased]\` \`### Fixed\`

## Verification

\`\`\`
\$ bundle exec rake test
265 runs, 701 assertions, 0 failures, 0 errors, 0 skips
Line Coverage: 99.55% (439 / 441)
Branch Coverage: 95.65% (88 / 92)

\$ bundle exec rubocop
45 files inspected, no offenses detected

\$ bundle exec steep check --jobs=1
No type error detected.
\`\`\`

Manual smoke locally via \`rake docs:serve\`:

- Light-mode inline \`code\` renders in steel-teal-dark on white,
  clearly legible
- Light-mode links still render in the same teal (consistent
  brand), distinguishable from code via the background pill
- Dark-mode inline \`code\` and dark-mode links unchanged

Contrast computation method: standard WCAG 2.1 relative-luminance
formula on linearized sRGB. `#2f4f5a` luminance ≈ 0.069; `#ffffff`
luminance = 1.0; ratio = (1.0 + 0.05) / (0.069 + 0.05) ≈ 8.30:1.

## Out of scope

- Dark-mode `highlightColor` tuning (separate concern, no contrast
  issue)
- The OG card raster still carries the legacy `#009ffd` (still
  needs external regeneration; flagged on #188 and #190)