### PR TITLE
docs: drop Roadmap and Changelog from public nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **GitHub Pages — drop Roadmap and Changelog from the public nav**:
+  the sidebar (`docs/_sidebar.md`) and the "Where to next" table
+  on the landing page (`docs/index.md`) both used to list
+  Roadmap and Changelog as primary destinations. Both are
+  contributor-facing artefacts — the roadmap tracks internal
+  milestone planning, and the changelog is the verbatim
+  `Keep a Changelog` history used for releases — neither tells a
+  reader how to use the gem. Removed both entries from the sidebar
+  and from the landing-page table. The pages themselves still live
+  under `docs/roadmap.md` and `docs/changelog.md` and remain
+  reachable by direct URL (the self-link in `roadmap.md` and the
+  release-process tooling in `docs/v1/*` still resolve), they're
+  just no longer surfaced as navigation.
+
 - **GitHub Pages — drop internal milestone tags from public copy**:
   the user-facing docs (api reference, deprecations, roadmap,
   every guide page) used to suffix headings and prose with

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,6 +1,6 @@
 <!-- Sidebar (Docsify reads this on every route).
      Order mirrors the Jekyll nav: Home, Getting started, Guides,
-     API reference, Deprecations, Examples, Roadmap, Changelog. -->
+     API reference, Deprecations, Examples. -->
 
 - [Home](/)
 - [Getting started](getting-started.md)
@@ -23,9 +23,6 @@
   - [Execute callbacks](examples/execute-callbacks.md)
   - [Instrumentation notifier](examples/instrumentation-notifier.md)
   - [RBS generator](examples/rbs-generator.md)
-
-- [Roadmap](roadmap.md)
-- [Changelog](changelog.md)
 
 - **Links**
   - [GitHub](https://github.com/ramongr/assistant)

--- a/docs/index.md
+++ b/docs/index.md
@@ -108,8 +108,6 @@ The same call returns `:with_warnings` if `#execute` logged any warnings, and
 | [RBS and types](guides/rbs-and-types.md) | Hand-curated sidecars + `bin/assistant-rbs`. |
 | [API reference](api-reference.md) | Every Frozen symbol in 1.0, deep-link friendly. |
 | [Examples](examples/rails-service.md) | Wiring patterns — Rails, CLI, Sidekiq, callbacks, notifier, RBS. |
-| [Roadmap](roadmap.md) | What's planned, what shipped, parallel deliverables. |
-| [Changelog](changelog.md) | Release history and migration notes. |
 | [Deprecations](deprecations.md) | What's flagged for removal in 2.0. |
 
 ---


### PR DESCRIPTION
## Scope

Trim the Docsify nav so it only surfaces user-task pages. The roadmap
and changelog are contributor artefacts — neither answers \"how do I
use this gem?\" — so they no longer belong in the sidebar or in the
landing-page \"Where to next\" table.

## What this PR ships

- \`docs/_sidebar.md\` — drop the two top-level entries (\`Roadmap\`,
  \`Changelog\`) between \`Examples\` and \`Links\`. Comment updated
  to reflect the new section list.
- \`docs/index.md\` — drop the matching rows from the \"Where to
  next\" table.
- \`CHANGELOG.md\` — entry under \`## [Unreleased]\` → \`### Changed\`
  recording the nav cleanup and noting that both pages still live
  under \`docs/roadmap.md\` and \`docs/changelog.md\` (still reachable
  by direct URL; the self-link in \`roadmap.md\` still resolves,
  and \`docs/v1/*\` release-process docs continue to reference the
  changelog).

No code changes. No file deletions. No anchor breakage.

## Resulting sidebar

\`\`\`
- Home
- Getting started
- Guides
  - Inputs
  - Validation
  - Logging and results
  - Composing services
  - RBS and types
- API reference
- Deprecations
- Examples
  - Rails service
  - CLI handler
  - Sidekiq worker
  - Composing services
  - Execute callbacks
  - Instrumentation notifier
  - RBS generator
- Links
  - GitHub
  - RubyGems
\`\`\`

## Verification

\`\`\`
$ bundle exec rake test
265 runs, 701 assertions, 0 failures, 0 errors, 0 skips
Line Coverage: 99.55% (439 / 441)
Branch Coverage: 95.65% (88 / 92)

$ bundle exec rubocop
45 files inspected, no offenses detected

$ bundle exec steep check --jobs=1
No type error detected.
\`\`\`

## Out of scope

- Not deleting \`docs/roadmap.md\` or \`docs/changelog.md\` — both still
  live in the repo and remain reachable via
  \`https://ramongr.github.io/assistant/#/roadmap\` and \`#/changelog\`.
- Not touching the root \`CHANGELOG.md\` content beyond the new
  \`Unreleased\` entry — that file is the canonical history.
- Not touching \`docs/v1/*\` working docs.