### PR TITLE
docs: strip leftover Jekyll/Kramdown syntax from docsify site

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,6 +1,6 @@
 <!-- Sidebar (Docsify reads this on every route).
-     Order mirrors the Jekyll nav: Home, Getting started, Guides,
-     API reference, Deprecations, Examples. -->
+     Order: Home, Getting started, Guides, API reference, Deprecations,
+     Examples. -->
 
 - [Home](/)
 - [Getting started](getting-started.md)
@@ -16,6 +16,7 @@
 - [Deprecations](deprecations.md)
 
 - **Examples**
+  - [Overview](examples/README.md)
   - [Rails service](examples/rails-service.md)
   - [CLI handler](examples/cli-handler.md)
   - [Sidekiq worker](examples/sidekiq-worker.md)

--- a/docs/examples/cli-handler.md
+++ b/docs/examples/cli-handler.md
@@ -1,5 +1,4 @@
 # CLI handler
-{: .no_toc }
 
 An `OptionParser`-driven script that runs a service and derives the
 process exit code from `#status`:

--- a/docs/examples/composing-services.md
+++ b/docs/examples/composing-services.md
@@ -1,5 +1,4 @@
 # Composing services
-{: .no_toc }
 
 `#call_service` runs a sibling service from inside `#execute` and
 merges its log timeline into the outer service automatically — see the

--- a/docs/examples/execute-callbacks.md
+++ b/docs/examples/execute-callbacks.md
@@ -1,5 +1,4 @@
 # Execute callbacks
-{: .no_toc }
 
 `before_execute` / `after_execute` / `around_execute` fire around the
 `#execute` body — see the [Composing services guide](../guides/composing-services.md#execute-callbacks)

--- a/docs/examples/instrumentation-notifier.md
+++ b/docs/examples/instrumentation-notifier.md
@@ -1,5 +1,4 @@
 # Instrumentation notifier
-{: .no_toc }
 
 `Assistant.notifier=` accepts any object responding to `#call(event,
 payload)`. Set it once at boot to wire every service into your
@@ -46,10 +45,9 @@ on `:service_executed` and `:service_failed`, `errors:` on
 [full payload table](../api-reference.md#instrumentation-notifier) for
 the exhaustive list.
 
-{: .warning }
-> Notifier callables are rescued from `StandardError`; any exception
-> they raise is `warn`-ed but doesn't fail the service. Don't put
-> control flow in the notifier.
+> **Warning** — Notifier callables are rescued from `StandardError`;
+> any exception they raise is `warn`-ed but doesn't fail the service.
+> Don't put control flow in the notifier.
 
 {: .note }
 > A runnable `examples/instrumentation_notifier/` script + integration

--- a/docs/examples/rails-service.md
+++ b/docs/examples/rails-service.md
@@ -1,5 +1,4 @@
 # Rails service
-{: .no_toc }
 
 A Rails-shaped controller that calls a service and pattern-matches on
 the result hash:

--- a/docs/examples/rbs-generator.md
+++ b/docs/examples/rbs-generator.md
@@ -1,5 +1,4 @@
 # RBS generator
-{: .no_toc }
 
 `bin/assistant-rbs` (installed as the `assistant-rbs` executable when
 the gem is added to a `Gemfile`) scans a source tree for

--- a/docs/examples/sidekiq-worker.md
+++ b/docs/examples/sidekiq-worker.md
@@ -1,5 +1,4 @@
 # Sidekiq worker
-{: .no_toc }
 
 A Sidekiq worker that runs a service idempotently and routes warnings
 and errors to separate sinks:

--- a/docs/v1/08-github-pages.md
+++ b/docs/v1/08-github-pages.md
@@ -184,9 +184,14 @@ Each example PR ships **all three** of:
 
 ## Acceptance criteria
 
-- [x] `bundle exec jekyll build --strict_front_matter` passes locally and in CI.
+- [x] ~~`bundle exec jekyll build --strict_front_matter` passes locally
+      and in CI.~~ _Superseded by docsify migration in PR #187: the
+      `docs.yml` workflow uploads `docs/` to Pages directly via
+      `actions/upload-pages-artifact@v3`; local preview is `rake
+      docs:serve`._
 - [x] `https://ramongr.github.io/assistant/` returns 200 and renders the
-      full nav (live since the Jekyll migration in PR #180).
+      full nav (live since the Jekyll migration in PR #180, still live
+      after the docsify swap in PR #187).
 - [x] Every page in the **Site map** exists (placeholder is acceptable
       after P2; real content after the matching Pn).
 - [ ] Every code block tagged ```` ```ruby ```` in `docs/getting-started.md`,
@@ -197,13 +202,17 @@ Each example PR ships **all three** of:
       ships the runnable examples.
 - [ ] Search box returns sensible results for "input", "warnings",
       "call_service", "notifier", "RBS".
-- [x] Dark-mode toggle works. Shipped as a custom button wired through
-      `_includes/head_custom.html` + `_includes/nav_footer_custom.html`
-      with `localStorage` persistence on top of just-the-docs's built-in
-      `jtd.setTheme()` API (the bundled toggle in 0.12 doesn't surface a
-      visible control on `color_scheme: light`).
-- [x] Repo-edit-this-page link on every page points at the right file on
-      `main` (driven by `_config.yml` `gh_edit_*` settings).
+- [x] Dark-mode toggle works. ~~Shipped as a custom button wired
+      through `_includes/head_custom.html` +
+      `_includes/nav_footer_custom.html` with `localStorage` persistence
+      on top of just-the-docs's built-in `jtd.setTheme()` API.~~
+      _Superseded by docsify migration in PR #187: now served by
+      docsify's `darkMode` plugin configured in `docs/index.html`._
+- [x] ~~Repo-edit-this-page link on every page points at the right file
+      on `main` (driven by `_config.yml` `gh_edit_*` settings).~~
+      _Superseded by docsify migration in PR #187: docsify renders an
+      "Edit this page" link from the `repo` + `loadSidebar` config in
+      `docs/index.html` without a `_config.yml`._
 - [x] Site polish bundle: copy-code button (`enable_copy_code_button`),
       named callouts (`note`/`tip`/`warning`/`important`), Mermaid loader
       pinned to `10.9.1`, baseurl-aware favicons (SVG + 32px + 180px


### PR DESCRIPTION
## Scope

Pure docs hygiene. Cleans up Jekyll/Kramdown artefacts that survived the docsify migration (PR #187) and were rendering as literal text on the live site, plus a missing sidebar entry for the Examples gallery. No Ruby touched.

This is **PR 1 / Thread A** of the [GitHub Pages improvements plan](https://github.com/ramongr/assistant/blob/main/docs/v1/08-github-pages.md). Thread B (materialising the seven `examples/<slug>/` folders to fulfil P6–P12) is queued separately.

## What this PR ships

- **Kramdown IAL removal.** Drops the `{: .no_toc }` directive directly under the H1 on all seven example pages (`docs/examples/{rails-service,cli-handler,sidekiq-worker,composing-services,execute-callbacks,instrumentation-notifier,rbs-generator}.md`). Docsify does not understand Kramdown IAL syntax, so these were rendering as visible text on the site.
- **Standalone `{: .warning }` block converted.** `docs/examples/instrumentation-notifier.md:49` becomes a portable `> **Warning**` blockquote.
- **Trailing `{: .note }` 'ships in Pₙ' callouts intentionally left in place.** They will be replaced wholesale by the per-example PRs (P6–P12) that create `examples/<slug>/`.
- **Sidebar Examples Overview link.** `docs/_sidebar.md` now lists `Overview → examples/README.md` as the first entry under **Examples**. Previously the gallery was reachable only via the landing page or a typed URL. The 'Order mirrors the Jekyll nav' comment is dropped.
- **Stale Jekyll acceptance criteria struck through.** In `docs/v1/08-github-pages.md`:
  - `bundle exec jekyll build --strict_front_matter passes locally and in CI.` — superseded.
  - The dark-mode toggle line referencing `_includes/head_custom.html` + `_includes/nav_footer_custom.html` + `jtd.setTheme()` — superseded.
  - The repo-edit-this-page line referencing `_config.yml gh_edit_*` — superseded.
  - Each gets a one-line `_Superseded by docsify migration in PR #187: …_` note so the historical decision trail survives.
- **Local-disk hygiene.** The untracked `docs/.jekyll-cache/` directory was deleted on disk during this branch's work. It was never tracked in git, so nothing to commit.

## Out of scope (intentionally)

- `docs/.nojekyll` stays. Docsify needs it so GitHub Pages skips Jekyll preprocessing.
- The seven `{: .note }` Pₙ callouts at the bottom of each example page stay. The matching B3 sweep replaces them when their `examples/<slug>/` folder lands.
- Materialising `examples/rails_service/`, `examples/cli_handler/`, … is Thread B of the plan (~8 PRs).
- Linking the orphan `docs/changelog.md` / `docs/roadmap.md` into the sidebar — those were intentionally dropped from public nav by PR #193.

## Verification

\`\`\`
$ bundle exec rake test
265 runs, 701 assertions, 0 failures, 0 errors, 0 skips
Line Coverage: 99.55% (439 / 441)

$ bundle exec rubocop
45 files inspected, no offenses detected

$ bundle exec steep check --jobs=1
No type error detected. 🫖
\`\`\`