### PR TITLE
docs: materialize examples/cli_handler runnable example (P7)

### DIFF
--- a/examples/cli_handler/README.md
+++ b/examples/cli_handler/README.md
@@ -1,0 +1,43 @@
+# CLI handler
+
+How to drive an `Assistant::Service` from an `OptionParser`-based
+command-line script and turn the result hash's `:status` into a
+meaningful process exit code. The matching site page is
+[`docs/examples/cli-handler.md`](../../docs/examples/cli-handler.md);
+this directory is the runnable mirror referenced from that page.
+
+## Files
+
+| File | Role |
+| --- | --- |
+| [`create_user.rb`](./create_user.rb) | The service: `email` + `name` inputs, fails with `:with_errors` when the email is missing `@`, demotes to `:with_warnings` when the name is all-lowercase (so the smoke test can exercise the warning branch without a third input). |
+| [`create_user_cli.rb`](./create_user_cli.rb) | Executable script (`chmod +x`) with the `OptionParser` setup and the three-way case-match on the result. Exits 0 for `:ok` / `:with_warnings`, exits 1 for `:with_errors`. |
+
+## Running it manually
+
+```sh
+$ bundle exec ruby examples/cli_handler/create_user_cli.rb --email a@b.com --name Alice
+ok: {id: 42, email: "a@b.com", name: "Alice"}
+
+$ bundle exec ruby examples/cli_handler/create_user_cli.rb --email a@b.com --name alice
+ok (with warnings): {id: 42, email: "a@b.com", name: "alice"}
+  warning: name not capitalized
+
+$ bundle exec ruby examples/cli_handler/create_user_cli.rb --email oops --name Alice
+error: must contain @
+$ echo $?
+1
+```
+
+The regression test
+[`test/examples/cli_handler_example_test.rb`](../../test/examples/cli_handler_example_test.rb)
+shells out to the script with `Open3.capture3` and asserts on the exit
+code + `$stderr` text for each branch.
+
+## Why a top-level `CreateUser` alias?
+
+The runnable script defines `CreateUser = CliHandlerExample::CreateUser`
+so its body reads line-for-line like the snippet in the docs page.
+Loading the service file in a test (which `require`s
+`examples/cli_handler/create_user`) only sees the namespaced class, so
+the alias does not leak between sibling tests.

--- a/examples/cli_handler/create_user.rb
+++ b/examples/cli_handler/create_user.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'assistant'
+
+module CliHandlerExample
+  # Example `Assistant::Service` for `examples/cli_handler/`. Mirrors
+  # the service shown verbatim in `docs/examples/cli-handler.md`:
+  # validates the email contains `@`, emits a warning when `name` is
+  # all-lowercase (so the CLI smoke test can exercise the
+  # `:with_warnings` branch without needing extra inputs).
+  class CreateUser < Assistant::Service
+    input :email, type: String, required: true
+    input :name, type: String, required: true
+
+    def validate
+      return if email.include?('@')
+
+      log_item_error(source: :validate, detail: :email, message: 'must contain @')
+    end
+
+    def execute
+      log_item_warning(source: :execute, detail: :name, message: 'name not capitalized') if name == name.downcase
+
+      { id: 42, email:, name: }
+    end
+  end
+end

--- a/examples/cli_handler/create_user_cli.rb
+++ b/examples/cli_handler/create_user_cli.rb
@@ -1,15 +1,22 @@
-# CLI handler
-
-An `OptionParser`-driven script that runs a service and derives the
-process exit code from `#status`:
-
-```ruby
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+# `examples/cli_handler/` runnable CLI. Drives the service in
+# `create_user.rb` from `OptionParser` and derives the process exit
+# code from the result hash's `:status`. Mirrors the script shown
+# verbatim in `docs/examples/cli-handler.md`.
+#
+# Top-level `CreateUser` is aliased to the namespaced
+# `CliHandlerExample::CreateUser` so the body of the script reads
+# exactly like the docs snippet.
+
+# Require order intentionally matches the docs snippet
+# (`stdlib`, `assistant`, `require_relative`) rather than alphabetical.
 require 'optparse'
-require 'assistant'
+require 'assistant' # rubocop:disable Style/RequireOrder
 require_relative 'create_user'
+
+CreateUser = CliHandlerExample::CreateUser unless defined?(CreateUser)
 
 options = {}
 OptionParser.new do |opts|
@@ -30,14 +37,3 @@ in { errors:, status: :with_errors }
   errors.each { |e| warn "error: #{e.message}" }
   exit 1
 end
-```
-
-Notes:
-
-* `:ok` and `:with_warnings` both exit 0 — warnings are still a
-  successful run. Only `:with_errors` exits 1.
-* Print to `$stderr` (`warn`) so the script can be piped without log
-  noise leaking into stdout.
-
-> Source: [`examples/cli_handler/`](https://github.com/ramongr/assistant/tree/main/examples/cli_handler) ·
-> Test: [`test/examples/cli_handler_example_test.rb`](https://github.com/ramongr/assistant/blob/main/test/examples/cli_handler_example_test.rb)

--- a/test/examples/cli_handler_example_test.rb
+++ b/test/examples/cli_handler_example_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+require 'open3'
+
+# Regression test for `examples/cli_handler/` (P7 of
+# docs/v1/08-github-pages.md). Shells out to
+# `examples/cli_handler/create_user_cli.rb` and asserts on the exit
+# code + stderr text for each `case … in …` branch promised by
+# `docs/examples/cli-handler.md`.
+class CliHandlerExampleTest < Minitest::Test
+  CLI_SCRIPT = File.join(ExampleTestHelpers::EXAMPLES_ROOT, 'cli_handler', 'create_user_cli.rb')
+
+  def test_happy_path_exits_zero_and_writes_ok_line
+    stdout, stderr, status = run_cli('--email', 'a@b.com', '--name', 'Alice')
+
+    assert_predicate status, :success?
+    assert_equal 0, status.exitstatus
+    assert_empty stdout
+    assert_match(/\Aok: \{.*id.*42.*\}/, stderr.lines.first)
+  end
+
+  def test_with_warnings_exits_zero_and_lists_warnings_on_stderr
+    stdout, stderr, status = run_cli('--email', 'a@b.com', '--name', 'alice')
+
+    assert_predicate status, :success?
+    assert_equal 0, status.exitstatus
+    assert_empty stdout
+    assert_match(/\Aok \(with warnings\):/, stderr.lines.first)
+    assert_includes stderr, '  warning: name not capitalized'
+  end
+
+  def test_with_errors_exits_nonzero_and_lists_errors_on_stderr
+    stdout, stderr, status = run_cli('--email', 'oops', '--name', 'Alice')
+
+    refute_predicate status, :success?
+    assert_equal 1, status.exitstatus
+    assert_empty stdout
+    assert_includes stderr, 'error: must contain @'
+  end
+
+  private
+
+  # Runs the CLI in a child Ruby with the gem's `lib/` on `$LOAD_PATH`
+  # so `require 'assistant'` resolves without an installed gem.
+  def run_cli(*)
+    Open3.capture3(RbConfig.ruby, '-I', File.expand_path('../../lib', __dir__), CLI_SCRIPT, *)
+  end
+end


### PR DESCRIPTION
## Scope

Implements **P7** of the GitHub Pages plan (`docs/v1/08-github-pages.md:148-170`): the second of the seven runnable example folders the docs site has been linking to.

## What this PR ships

- **`examples/cli_handler/`** \u2014 an `OptionParser`-driven CLI that runs a service and exits 0/1 based on `#status`:
  - `create_user.rb` \u2014 `CliHandlerExample::CreateUser < Assistant::Service`. Email + name inputs; fails with `:with_errors` when the email is missing `@`, demotes to `:with_warnings` when the name is all-lowercase (so the smoke test can hit the middle branch without a third input).
  - `create_user_cli.rb` \u2014 executable script (\`chmod +x\` shebang) that aliases the namespaced class to top-level `CreateUser` so its body reads line-for-line like the docs snippet.
  - \`README.md\` \u2014 first sentence states the problem, plus manual-run examples for each branch.
- **\`test/examples/cli_handler_example_test.rb\`** \u2014 shells out via \`Open3.capture3\` and asserts on exit code + \`\$stderr\` text for \`:ok\`, \`:with_warnings\`, and \`:with_errors\`. Runs the child Ruby with the gem's \`lib/\` on \`\$LOAD_PATH\` so it works without an installed gem.
- **\`docs/examples/cli-handler.md\`** \u2014 the trailing Jekyll \`{: .note }\` 'ships in P7\u2026' callout is replaced with the standard \`> Source: \u2026 \u00b7 Test: \u2026\` blockquote.

## Why a top-level \`CreateUser\` alias?

The script body in the docs page is the teaching artifact. Keeping it byte-identical means the docs and the runnable file stay in lockstep without a regression test on snippet drift. The alias never leaves the script (loading \`create_user.rb\` from a test still only sees the namespaced class) so sibling tests are not polluted.

## Verification

\`\`\`
$ bundle exec rake test
271 runs, 738 assertions, 0 failures, 0 errors, 0 skips
Line Coverage: 99.57% (468 / 470) | Branch Coverage: 95.0% (95 / 100)

$ bundle exec rubocop
52 files inspected, no offenses detected

$ bundle exec steep check --jobs=1
# no type errors

# Manual smoke
\$ bundle exec ruby examples/cli_handler/create_user_cli.rb --email a@b.com --name Alice
ok: {id: 42, email: \"a@b.com\", name: \"Alice\"}
\`\`\`

## Out of scope

- P8\u2013P12 ship one-PR-at-a-time per the v1 plan.
- The acceptance-criteria checkbox in \`docs/v1/08-github-pages.md:192-197\` is ticked in the final B4 PR once every example folder has landed.