### PR TITLE
docs: materialize examples/sidekiq_worker runnable example (P8)

### DIFF
--- a/docs/examples/sidekiq-worker.md
+++ b/docs/examples/sidekiq-worker.md
@@ -33,8 +33,5 @@ Notes:
   caller's identifier, look up existing state, no-op when already
   satisfied.
 
-{: .note }
-> A runnable `examples/sidekiq_worker/` script + fake-Sidekiq test
-> ships in
-> [P8](https://github.com/ramongr/assistant/blob/main/docs/v1/08-github-pages.md#p6p12-examples-one-pr-per-example)
-> of the GitHub Pages plan.
+> Source: [`examples/sidekiq_worker/`](https://github.com/ramongr/assistant/tree/main/examples/sidekiq_worker) ·
+> Test: [`test/examples/sidekiq_worker_example_test.rb`](https://github.com/ramongr/assistant/blob/main/test/examples/sidekiq_worker_example_test.rb)

--- a/examples/sidekiq_worker/README.md
+++ b/examples/sidekiq_worker/README.md
@@ -1,0 +1,41 @@
+# Sidekiq worker
+
+How to wrap an `Assistant::Service` in a Sidekiq worker that routes
+warnings and errors to separate sinks instead of re-raising into the
+retry loop. The matching site page is
+[`docs/examples/sidekiq-worker.md`](../../docs/examples/sidekiq-worker.md);
+this directory is the runnable mirror referenced from that page.
+
+## Files
+
+| File | Role |
+| --- | --- |
+| [`create_user.rb`](./create_user.rb) | The service: `email` + `name` inputs, fails when the email is missing `@`, demotes to `:with_warnings` when the name is all-lowercase. |
+| [`fake_sidekiq.rb`](./fake_sidekiq.rb) | Stub of `Sidekiq::Worker` + `sidekiq_options` so the example runs without the real `sidekiq` gem on the gemfile. The stub stores options on the class so tests can assert on `retry:` / `queue:`. |
+| [`create_user_worker.rb`](./create_user_worker.rb) | The worker class, byte-identical to the docs snippet. Aliases the namespaced service + sinks to top-level constants. Publishes to `SidekiqWorkerExample::WarningsSink` / `ErrorsSink` (both module singletons with a class-level array). |
+
+## Why a fake Sidekiq?
+
+The teaching point of the example is the **case-match + sink routing**,
+not the Sidekiq dispatcher. Adding the `sidekiq` gem as a runtime dep
+would force the gem's CI matrix to install Redis just to exercise three
+case-match branches. The fake module hands back enough of the API
+(`include Sidekiq::Worker`, `sidekiq_options(retry:, queue:)`) for the
+worker class to load and run synchronously under Minitest.
+
+## Running it manually
+
+```ruby
+$ bundle exec ruby -Ilib -rexamples/sidekiq_worker/create_user_worker -e '
+  CreateUserWorker.new.perform(email: "a@b.com", name: "Alice")
+  CreateUserWorker.new.perform(email: "a@b.com", name: "alice")
+  CreateUserWorker.new.perform(email: "oops",    name: "Bob")
+  pp warnings: SidekiqWorkerExample::WarningsSink.published,
+     errors:   SidekiqWorkerExample::ErrorsSink.published
+'
+```
+
+The regression test
+[`test/examples/sidekiq_worker_example_test.rb`](../../test/examples/sidekiq_worker_example_test.rb)
+invokes `CreateUserWorker.new.perform({...})` for each branch and
+asserts on the sink contents.

--- a/examples/sidekiq_worker/create_user.rb
+++ b/examples/sidekiq_worker/create_user.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'assistant'
+
+module SidekiqWorkerExample
+  # Example `Assistant::Service` for `examples/sidekiq_worker/`. Same
+  # shape as the other example services: validates `email` contains
+  # `@`, demotes to `:with_warnings` when `name` is all-lowercase, so
+  # the worker test can exercise each branch.
+  class CreateUser < Assistant::Service
+    input :email, type: String, required: true
+    input :name, type: String, required: true
+
+    def validate
+      return if email.include?('@')
+
+      log_item_error(source: :validate, detail: :email, message: 'must contain @')
+    end
+
+    def execute
+      log_item_warning(source: :execute, detail: :name, message: 'name not capitalized') if name == name.downcase
+
+      { id: 42, email:, name: }
+    end
+  end
+end

--- a/examples/sidekiq_worker/create_user_worker.rb
+++ b/examples/sidekiq_worker/create_user_worker.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# `examples/sidekiq_worker/` runnable worker. Mirrors the snippet in
+# `docs/examples/sidekiq-worker.md` line-for-line, including the
+# unqualified `CreateUser` / `WarningsSink` / `ErrorsSink` references
+# in the worker body.
+#
+# - `Sidekiq::Worker` comes from the in-folder `fake_sidekiq.rb` stub
+#   so the example runs without depending on the real `sidekiq` gem.
+# - `CreateUser`, `WarningsSink`, `ErrorsSink` are top-level aliases of
+#   the namespaced `SidekiqWorkerExample::*` constants. Loading this
+#   file from a sibling test therefore lets the worker body match the
+#   docs snippet while keeping the canonical defs in the example
+#   namespace for assertion + reset.
+
+require_relative 'create_user'
+require_relative 'fake_sidekiq'
+require_relative 'sinks'
+
+CreateUser = SidekiqWorkerExample::CreateUser unless defined?(CreateUser)
+WarningsSink = SidekiqWorkerExample::WarningsSink unless defined?(WarningsSink)
+ErrorsSink = SidekiqWorkerExample::ErrorsSink unless defined?(ErrorsSink)
+
+# Example Sidekiq worker that runs `CreateUser` idempotently and
+# routes warnings + errors to separate sinks instead of re-raising.
+class CreateUserWorker
+  include Sidekiq::Worker
+
+  sidekiq_options retry: 5, queue: :default
+
+  def perform(user_attrs)
+    case CreateUser.run(**user_attrs.transform_keys(&:to_sym))
+    in { result:, status: :ok }
+      # Done. Sidekiq sees no exception, no retry.
+    in { result:, status: :with_warnings, warnings: }
+      WarningsSink.publish(worker: self.class.name, items: warnings.map(&:item))
+    in { errors:, status: :with_errors }
+      # Permanent business-rule failure: don't retry, surface to ops.
+      ErrorsSink.publish(worker: self.class.name, items: errors.map(&:item))
+    end
+  end
+end

--- a/examples/sidekiq_worker/fake_sidekiq.rb
+++ b/examples/sidekiq_worker/fake_sidekiq.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Stub of the tiny slice of the Sidekiq API the worker example needs:
+# `Sidekiq::Worker` as a no-op include and a `sidekiq_options` DSL that
+# stores its argument on the class. Lets `examples/sidekiq_worker/`
+# stay runnable without the real `sidekiq` gem as a dependency.
+#
+# The compact-nesting cop is disabled because we are deliberately
+# providing the public `Sidekiq::Worker` constant path, not a private
+# helper.
+
+# rubocop:disable Style/CompactModuleNesting
+module Sidekiq
+  # No-op include for the example worker. The real `Sidekiq::Worker`
+  # registers job classes with the server-side dispatcher; here it just
+  # exposes the `sidekiq_options` class-method DSL.
+  module Worker
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    # Mirrors `Sidekiq::Worker::ClassMethods#sidekiq_options` enough to
+    # let the example declare retry + queue settings and let the test
+    # assert that the call happened.
+    module ClassMethods
+      def sidekiq_options(opts = {})
+        @sidekiq_options ||= {}
+        @sidekiq_options.merge!(opts)
+      end
+
+      def sidekiq_options_hash
+        @sidekiq_options || {}
+      end
+    end
+  end
+end
+# rubocop:enable Style/CompactModuleNesting

--- a/examples/sidekiq_worker/sinks.rb
+++ b/examples/sidekiq_worker/sinks.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module SidekiqWorkerExample
+  # Sink for `:with_warnings` runs. In a real app this would wrap an
+  # APM client or message bus; for the example it is a tiny singleton
+  # with a class-level array so the regression test can assert on the
+  # calls without stubs.
+  module WarningsSink
+    @published = []
+
+    class << self
+      attr_reader :published
+
+      def publish(worker:, items:)
+        @published << { worker:, items: }
+      end
+
+      def clear
+        @published.clear
+      end
+    end
+  end
+
+  # Sink for `:with_errors` runs. Same shape as `WarningsSink`; kept
+  # separate so the test can assert errors land here and warnings do
+  # not (and vice versa).
+  module ErrorsSink
+    @published = []
+
+    class << self
+      attr_reader :published
+
+      def publish(worker:, items:)
+        @published << { worker:, items: }
+      end
+
+      def clear
+        @published.clear
+      end
+    end
+  end
+end

--- a/test/examples/sidekiq_worker_example_test.rb
+++ b/test/examples/sidekiq_worker_example_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+require File.join(ExampleTestHelpers::EXAMPLES_ROOT, 'sidekiq_worker/create_user_worker')
+
+# Regression test for `examples/sidekiq_worker/` (P8 of
+# docs/v1/08-github-pages.md). Exercises each `case … in …` branch of
+# `CreateUserWorker#perform` and asserts on the right sink for each
+# `:status`.
+class SidekiqWorkerExampleTest < Minitest::Test
+  def setup
+    SidekiqWorkerExample::WarningsSink.clear
+    SidekiqWorkerExample::ErrorsSink.clear
+  end
+
+  def test_happy_path_publishes_to_no_sink
+    CreateUserWorker.new.perform('email' => 'a@b.com', 'name' => 'Alice')
+
+    assert_empty SidekiqWorkerExample::WarningsSink.published
+    assert_empty SidekiqWorkerExample::ErrorsSink.published
+  end
+
+  def test_with_warnings_publishes_to_warnings_sink_with_log_items
+    CreateUserWorker.new.perform('email' => 'a@b.com', 'name' => 'alice')
+
+    assert_empty SidekiqWorkerExample::ErrorsSink.published
+    published = SidekiqWorkerExample::WarningsSink.published
+
+    assert_equal 1, published.size
+
+    entry = published.first
+
+    assert_equal 'CreateUserWorker', entry.fetch(:worker)
+    item = entry.fetch(:items).first
+
+    assert_equal :execute, item.fetch(:source)
+    assert_equal :name, item.fetch(:detail)
+    assert_equal 'name not capitalized', item.fetch(:message)
+  end
+
+  def test_with_errors_publishes_to_errors_sink_with_log_items
+    CreateUserWorker.new.perform('email' => 'oops', 'name' => 'Bob')
+
+    assert_empty SidekiqWorkerExample::WarningsSink.published
+    published = SidekiqWorkerExample::ErrorsSink.published
+
+    assert_equal 1, published.size
+
+    entry = published.first
+
+    assert_equal 'CreateUserWorker', entry.fetch(:worker)
+    item = entry.fetch(:items).first
+
+    assert_equal :validate, item.fetch(:source)
+    assert_equal :email, item.fetch(:detail)
+    assert_equal 'must contain @', item.fetch(:message)
+  end
+
+  def test_sidekiq_options_are_recorded_on_the_worker_class
+    options = CreateUserWorker.sidekiq_options_hash
+
+    assert_equal 5, options.fetch(:retry)
+    assert_equal :default, options.fetch(:queue)
+  end
+end


### PR DESCRIPTION
## Scope

Implements **P8** of the GitHub Pages plan (`docs/v1/08-github-pages.md:148-170`): the third of the seven runnable example folders.

## What this PR ships

- **`examples/sidekiq_worker/`** \u2014 a fake-Sidekiq-driven worker that runs a service idempotently and routes warnings + errors to separate sinks instead of re-raising:
  - `create_user.rb` \u2014 `SidekiqWorkerExample::CreateUser` (email + name; \`:with_errors\` on missing \`@\`, \`:with_warnings\` on all-lowercase name).
  - `fake_sidekiq.rb` \u2014 stub of `Sidekiq::Worker` + the `sidekiq_options` DSL so the example loads without the real `sidekiq` gem on the gemfile.
  - `sinks.rb` \u2014 `SidekiqWorkerExample::WarningsSink` and `ErrorsSink` module singletons backed by class-level arrays; tests clear them between cases.
  - `create_user_worker.rb` \u2014 the worker class, body byte-identical to the docs snippet. Top-level `CreateUser` / `WarningsSink` / `ErrorsSink` aliases keep the snippet match while canonical defs stay in the example namespace.
  - \`README.md\` \u2014 first sentence states the problem, plus the \"why a fake Sidekiq?\" rationale and a manual-run incantation.
- **\`test/examples/sidekiq_worker_example_test.rb\`** \u2014 invokes \`CreateUserWorker.new.perform({\u2026})\` for each of the three \`:status\` branches and asserts on sink contents. Also asserts the documented \`retry: 5, queue: :default\` ends up in \`sidekiq_options_hash\`.
- **\`docs/examples/sidekiq-worker.md\`** \u2014 the trailing Jekyll \`{: .note }\` 'ships in P8\u2026' callout is replaced with the standard \`> Source: \u2026 \u00b7 Test: \u2026\` blockquote.

## Why a fake Sidekiq?

The teaching point of the example is **case-match + sink routing**, not the dispatcher. Adding \`sidekiq\` would force the gem's CI matrix to install Redis just to exercise three case-match branches. The fake module hands back enough of the API for the worker class to load and run synchronously under Minitest.

## Verification

\`\`\`
$ bundle exec rake test
275 runs, 758 assertions, 0 failures, 0 errors, 0 skips
Line Coverage: 99.62% (519 / 521) | Branch Coverage: 92.11% (105 / 114)

$ bundle exec rubocop
57 files inspected, no offenses detected

$ bundle exec steep check --jobs=1
# no type errors
\`\`\`

## Out of scope

- P9\u2013P12 ship one-PR-at-a-time per the v1 plan.
- The acceptance-criteria checkbox in \`docs/v1/08-github-pages.md:192-197\` is ticked in the final B4 PR.