### PR TITLE
docs: materialize examples/composing_services runnable example (P9)

### DIFF
--- a/docs/examples/composing-services.md
+++ b/docs/examples/composing-services.md
@@ -45,8 +45,5 @@ Notes:
   logs join the outer timeline. Calling `.run` directly silently
   discards them.
 
-{: .note }
-> A runnable `examples/composing_services/` script + integration test
-> ships in
-> [P9](https://github.com/ramongr/assistant/blob/main/docs/v1/08-github-pages.md#p6p12-examples-one-pr-per-example)
-> of the GitHub Pages plan.
+> Source: [`examples/composing_services/`](https://github.com/ramongr/assistant/tree/main/examples/composing_services) ·
+> Test: [`test/examples/composing_services_example_test.rb`](https://github.com/ramongr/assistant/blob/main/test/examples/composing_services_example_test.rb)

--- a/examples/composing_services/README.md
+++ b/examples/composing_services/README.md
@@ -1,0 +1,43 @@
+# Composing services
+
+How to nest one `Assistant::Service` inside another using
+`#call_service`, and verify the inner timeline merges into the outer
+one in declaration order. The matching site page is
+[`docs/examples/composing-services.md`](../../docs/examples/composing-services.md);
+this directory is the runnable mirror referenced from that page.
+
+## Files
+
+| File | Role |
+| --- | --- |
+| [`create_user.rb`](./create_user.rb) | First inner service. Validates `email`, then warns `:email_normalized` and returns a `User` data struct with `.id`. |
+| [`send_welcome_email.rb`](./send_welcome_email.rb) | Second inner service. Takes `user_id`, warns `:throttled`, returns a queued-acknowledgement hash. |
+| [`sign_up_user.rb`](./sign_up_user.rb) | Outer service. Calls `CreateUser` then (on success) `SendWelcomeEmail` via `#call_service`, byte-identical to the docs snippet. |
+
+## What the test pins
+
+The merged-timeline shape from
+[`docs/examples/composing-services.md`](../../docs/examples/composing-services.md)
+is the documented contract for `#call_service`. The regression test
+[`test/examples/composing_services_example_test.rb`](../../test/examples/composing_services_example_test.rb)
+asserts:
+
+- Happy path returns `status: :with_warnings` and exactly two
+  warnings, in the order `:email_normalized` (from `CreateUser`)
+  then `:throttled` (from `SendWelcomeEmail`).
+- The outer `#result` is the `User` returned by `CreateUser`, not the
+  hash returned by `SendWelcomeEmail` (the example keeps `user.result`
+  as the trailing expression).
+- When `CreateUser` fails (invalid email), `SignUpUser` short-circuits
+  before `SendWelcomeEmail` runs, the outer status is `:with_errors`,
+  and the inner `:email` error is on the outer timeline (because
+  `merge_logs` ran before the early return).
+
+## Running it manually
+
+```ruby
+$ bundle exec ruby -Ilib -rexamples/composing_services/sign_up_user -e '
+  pp ComposingServicesExample::SignUpUser.run(email: "a@b.com", name: "Alice")
+  pp ComposingServicesExample::SignUpUser.run(email: "oops",    name: "Alice")
+'
+```

--- a/examples/composing_services/create_user.rb
+++ b/examples/composing_services/create_user.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'assistant'
+
+module ComposingServicesExample
+  # Inner service for `examples/composing_services/`. Validates that
+  # `email` contains `@`, then always logs a `:email_normalized`
+  # warning so the outer `SignUpUser` test can assert on the merged
+  # timeline shape from `docs/examples/composing-services.md`.
+  class CreateUser < Assistant::Service
+    # Read-only value object returned from `#execute`. Mirrors the
+    # `<User>` shape rendered in the docs snippet.
+    User = Data.define(:id, :email, :name)
+
+    input :email, type: String, required: true
+    input :name, type: String, required: true
+
+    def validate
+      return if email.include?('@')
+
+      log_item_error(source: :validate, detail: :email, message: 'must contain @')
+    end
+
+    def execute
+      normalized = email.downcase
+      log_item_warning(source: :create_user, detail: :email_normalized, message: "normalized to #{normalized}")
+
+      User.new(id: 42, email: normalized, name:)
+    end
+  end
+end

--- a/examples/composing_services/send_welcome_email.rb
+++ b/examples/composing_services/send_welcome_email.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'assistant'
+
+module ComposingServicesExample
+  # Inner service for `examples/composing_services/`. Always logs a
+  # `:throttled` warning so the outer `SignUpUser` test can assert
+  # that the inner timeline merges into the outer one in declaration
+  # order (after `CreateUser`'s `:email_normalized` warning).
+  class SendWelcomeEmail < Assistant::Service
+    input :user_id, type: Integer, required: true
+
+    def execute
+      log_item_warning(source: :send_welcome_email, detail: :throttled, message: 'welcome queued for 1s delay')
+
+      { user_id:, queued: true }
+    end
+  end
+end

--- a/examples/composing_services/sign_up_user.rb
+++ b/examples/composing_services/sign_up_user.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative 'create_user'
+require_relative 'send_welcome_email'
+
+module ComposingServicesExample
+  # Outer service for `examples/composing_services/`. Calls
+  # `CreateUser` and (on success) `SendWelcomeEmail` via
+  # `#call_service`, which merges each inner timeline into this
+  # service's `#logs`. Mirrors the docs snippet at
+  # `docs/examples/composing-services.md` line for line.
+  class SignUpUser < Assistant::Service
+    input :email, type: String, required: true
+    input :name, type: String, required: true
+
+    def execute
+      user = call_service(CreateUser, email:, name:)
+      return if user.failure?
+
+      call_service(SendWelcomeEmail, user_id: user.result.id)
+
+      user.result
+    end
+  end
+end

--- a/test/examples/composing_services_example_test.rb
+++ b/test/examples/composing_services_example_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+require File.join(ExampleTestHelpers::EXAMPLES_ROOT, 'composing_services/sign_up_user')
+
+# Regression test for `examples/composing_services/` (P9 of
+# docs/v1/08-github-pages.md). Pins the merged-timeline shape
+# documented in `docs/examples/composing-services.md` lines 27-36:
+# `#call_service` merges each inner service's `#logs` into the outer
+# `@logs` in declaration order, so `CreateUser`'s `:email_normalized`
+# warning lands before `SendWelcomeEmail`'s `:throttled` warning, and
+# the outer status downgrades to `:with_warnings`.
+class ComposingServicesExampleTest < Minitest::Test
+  def test_happy_path_returns_inner_user_with_normalized_email
+    payload = ComposingServicesExample::SignUpUser.run(email: 'A@B.com', name: 'Alice')
+
+    assert_equal :with_warnings, payload.fetch(:status)
+
+    user = payload.fetch(:result)
+
+    assert_equal 42, user.id
+    assert_equal 'a@b.com', user.email
+    assert_equal 'Alice', user.name
+  end
+
+  def test_happy_path_merges_inner_warnings_in_declaration_order
+    payload = ComposingServicesExample::SignUpUser.run(email: 'A@B.com', name: 'Alice')
+    warnings = payload.fetch(:warnings)
+
+    assert_equal 2, warnings.size
+
+    first, second = warnings
+
+    assert_equal %i[create_user email_normalized], [first.source, first.detail]
+    assert_equal 'normalized to a@b.com', first.message
+
+    assert_equal %i[send_welcome_email throttled], [second.source, second.detail]
+    assert_equal 'welcome queued for 1s delay', second.message
+  end
+
+  def test_inner_failure_short_circuits_before_send_welcome_email_runs
+    payload = ComposingServicesExample::SignUpUser.run(email: 'oops', name: 'Alice')
+
+    assert_equal :with_errors, payload.fetch(:status)
+    assert_nil payload.fetch(:result)
+
+    errors = payload.fetch(:errors)
+
+    assert_equal 1, errors.size
+
+    error = errors.first
+
+    assert_equal :validate, error.source
+    assert_equal :email, error.detail
+    assert_equal 'must contain @', error.message
+  end
+
+  def test_inner_failure_does_not_log_send_welcome_email_throttled_warning
+    service = ComposingServicesExample::SignUpUser.new(email: 'oops', name: 'Alice')
+    service.run
+
+    refute(service.logs.any? { |log| log.detail == :throttled },
+           'SendWelcomeEmail should not have run when CreateUser failed')
+  end
+end


### PR DESCRIPTION
## Scope

Ninth example folder from the P6–P12 plan in
[`docs/v1/08-github-pages.md`](https://github.com/ramongr/assistant/blob/main/docs/v1/08-github-pages.md#p6p12-examples-one-pr-per-example).
Materializes the two-step signup snippet from
[`docs/examples/composing-services.md`](https://github.com/ramongr/assistant/blob/main/docs/examples/composing-services.md)
and pins the merged-timeline shape that snippet documents.

## What this PR ships

- \`examples/composing_services/create_user.rb\` — first inner service. Validates email contains \`@\`, normalises to lowercase, warns \`:email_normalized\` with the normalised value in the message. Returns a \`Data\`-defined \`User\` struct with \`#id\` / \`#email\` / \`#name\` so the outer can do \`user.result.id\` per the snippet.
- \`examples/composing_services/send_welcome_email.rb\` — second inner service. Takes \`user_id\`, warns \`:throttled\` with the documented message, returns a queued-acknowledgement hash.
- \`examples/composing_services/sign_up_user.rb\` — outer service. Byte-identical to the docs snippet: \`call_service(CreateUser)\`, early-return on failure, \`call_service(SendWelcomeEmail, user_id: user.result.id)\`, trailing \`user.result\` so the outer \`#result\` is the \`User\`.
- \`examples/composing_services/README.md\` — problem statement, file table, what-the-test-pins section, manual-run incantation.
- \`test/examples/composing_services_example_test.rb\` — three tests covering happy-path return shape, merged-warning declaration order (\`:email_normalized\` from \`CreateUser\` before \`:throttled\` from \`SendWelcomeEmail\`), and inner-failure short-circuit (no \`:throttled\` warning, inner \`:email\` error appears on the outer timeline via \`merge_logs\` before the early return).
- \`docs/examples/composing-services.md\` — closing \`{: .note }\` 'ships in P9…' Jekyll callout replaced with the standard \`Source\` + \`Test\` blockquote pattern used by P6–P8.

## Why the test matters

\`#call_service\` is the entire teaching point of this page; the assertion that the inner timelines merge **in declaration order** is what users rely on when reasoning about \`status: :with_warnings\` vs \`:with_errors\` downstream. The test pins both the order and the message text rendered in the docs.

## Verification

- \`bundle exec rake test\` → 279 runs / 774 assertions / 0 failures (was 275 / 758 before P9). Line cov 99.64%, branch cov 92.37%.
- \`bundle exec rubocop\` → 61 files / no offenses.
- \`bundle exec steep check --jobs=1\` → no type errors.

## Out of scope

- P10 (\`execute_callbacks\`), P11 (\`instrumentation_notifier\`), P12 (\`rbs_generator\`) — each ships as its own PR per the M-numbered plan.
- B4 acceptance-criteria tick-off in \`docs/v1/08-github-pages.md\` — ships once P12 is in.