### PR TITLE
docs: materialize examples/execute_callbacks runnable example (P10)

### DIFF
--- a/docs/examples/execute-callbacks.md
+++ b/docs/examples/execute-callbacks.md
@@ -14,15 +14,16 @@ class AuditedService < Assistant::Service
     log_item_info(source: :audit, detail: :start, message: "user=#{user_id}")
   end
 
-  after_execute do
+  after_execute do |_result|
     log_item_info(source: :audit, detail: :finish, message: "user=#{user_id}")
   end
 
-  around_execute do |cont|
+  around_execute do |&blk|
     started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    cont.call
+    inner = blk.call
     elapsed_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000).round(1)
     log_item_info(source: :audit, detail: :timing, message: "#{elapsed_ms}ms")
+    inner
   end
 
   def execute
@@ -38,13 +39,15 @@ Failure semantics:
   running — it just becomes part of the result hash. Use the
   declarative `valid_*_*?` family or `#validate` when you need to
   short-circuit.
-* `around_execute` blocks **must** call `cont.call` (or `yield_*`)
-  exactly once. Skipping it silently drops the inner result.
-* If a hook itself raises, the exception propagates out of `#run`
-  uncaught — hooks are not soft-failed.
+* `around_execute` blocks receive the inner continuation as the block
+  argument (`&blk`) and **must** call it exactly once. Skipping
+  `blk.call` silently drops the inner result.
+* `after_execute` blocks receive the `#execute` return value as their
+  single positional arg.
+* If a hook itself raises, `Assistant::Service` rescues the
+  `StandardError` and logs it as
+  `source: :hook, detail: :before_execute|:around_execute|:after_execute`
+  — execution of subsequent hooks continues.
 
-{: .note }
-> A runnable `examples/execute_callbacks/` script + regression test
-> ships in
-> [P10](https://github.com/ramongr/assistant/blob/main/docs/v1/08-github-pages.md#p6p12-examples-one-pr-per-example)
-> of the GitHub Pages plan.
+> Source: [`examples/execute_callbacks/`](https://github.com/ramongr/assistant/tree/main/examples/execute_callbacks) ·
+> Test: [`test/examples/execute_callbacks_example_test.rb`](https://github.com/ramongr/assistant/blob/main/test/examples/execute_callbacks_example_test.rb)

--- a/examples/execute_callbacks/README.md
+++ b/examples/execute_callbacks/README.md
@@ -1,0 +1,45 @@
+# execute_callbacks example
+
+How to use `before_execute` / `after_execute` / `around_execute` hooks to
+add cross-cutting behaviour (audit logging + wall-time measurement) to
+a service without touching its `#execute` body. Companion to
+[`docs/examples/execute-callbacks.md`](../../docs/examples/execute-callbacks.md);
+see also the
+[Composing services guide](../../docs/guides/composing-services.md#execute-callbacks)
+for the full hook contract.
+
+## Files
+
+| File | What it shows |
+| --- | --- |
+| `audited_service.rb` | A `Service` subclass that registers all three hook types: a before-hook logs `:start`, an after-hook logs `:finish`, and an around-hook logs `:timing` with the elapsed milliseconds. |
+| `../../test/examples/execute_callbacks_example_test.rb` | Pins the observable hook order on the log timeline (`:start` → `:timing` → `:finish`) and the format of the `:timing` message. |
+
+## Why the observable order is `start` → `timing` → `finish`
+
+The around-hook brackets `cont.call` (the `#execute` body) but the
+`log_item_info(:timing)` line runs *after* `cont.call` returns.
+`Assistant::Service#run_execute_with_callbacks` (in
+`lib/assistant/service.rb`) wires it as:
+
+1. `run_before_execute_hooks` — emits `:start`.
+2. `run_around_execute_chain` — runs `cont.call` (no log yet) → `#execute` → then the `log_item_info(:timing)` line.
+3. `run_after_execute_hooks` — emits `:finish`.
+
+## Try it
+
+```sh
+bundle exec ruby -Ilib -rexamples/execute_callbacks/audited_service -e '
+  svc = ExecuteCallbacksExample::AuditedService.new(user_id: 42)
+  svc.run
+  svc.infos.each { |log| puts "#{log.detail}: #{log.message}" }
+'
+```
+
+Expected:
+
+```
+start: user=42
+timing: <n>ms
+finish: user=42
+```

--- a/examples/execute_callbacks/audited_service.rb
+++ b/examples/execute_callbacks/audited_service.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'assistant'
+
+# Companion to docs/examples/execute-callbacks.md.
+#
+# Shows how `before_execute` / `after_execute` / `around_execute` hooks
+# layer around `#execute`: a before-hook records `:start`, an around-hook
+# wraps the call to capture wall time as `:timing`, and an after-hook
+# records `:finish`. Hooks run in this observable order on the log
+# timeline: `:start` -> `:timing` -> `:finish`, because the around-hook's
+# log fires *after* `blk.call` returns, which itself happens between the
+# before- and after-hooks (see lib/assistant/service.rb#run_execute_with_callbacks).
+module ExecuteCallbacksExample
+  # A service whose business logic is intentionally trivial so the test
+  # can pin the hook-emitted log timeline without flakiness. The real
+  # body would live inside `#execute`; here it just echoes the input so
+  # downstream callers see a result hash they can pattern-match on.
+  class AuditedService < Assistant::Service
+    input :user_id, type: Integer, required: true
+
+    before_execute do
+      log_item_info(source: :audit, detail: :start, message: "user=#{user_id}")
+    end
+
+    after_execute do |_result|
+      log_item_info(source: :audit, detail: :finish, message: "user=#{user_id}")
+    end
+
+    around_execute do |&blk|
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      inner = blk.call
+      elapsed_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000).round(1)
+      log_item_info(source: :audit, detail: :timing, message: "#{elapsed_ms}ms")
+      inner
+    end
+
+    def execute
+      { user_id: }
+    end
+  end
+end

--- a/test/examples/execute_callbacks_example_test.rb
+++ b/test/examples/execute_callbacks_example_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require_relative 'test_helper'
+require File.join(ExampleTestHelpers::EXAMPLES_ROOT, 'execute_callbacks/audited_service')
+
+# Pins the observable log timeline produced by the `before_execute` /
+# `around_execute` / `after_execute` hooks registered on
+# `ExecuteCallbacksExample::AuditedService`. The around-hook's
+# `log_item_info(:timing)` line fires *after* `cont.call` returns, so
+# the user-visible order on `service.infos` is
+# `:start` → `:timing` → `:finish`. The timing-format test stays
+# non-flaky by accepting any non-negative duration that matches
+# `<digits>(.<digits>)?ms`.
+class ExecuteCallbacksExampleTest < Minitest::Test
+  def setup
+    @service = ExecuteCallbacksExample::AuditedService.new(user_id: 42)
+    @service.run
+  end
+
+  def test_emits_three_info_log_items_one_per_hook
+    assert_equal 3, @service.infos.size
+    assert_equal :ok, @service.status
+  end
+
+  def test_hook_emitted_details_appear_in_observable_order
+    assert_equal %i[start timing finish], @service.infos.map(&:detail)
+  end
+
+  def test_before_and_after_hooks_interpolate_user_id_in_message
+    start_log, _timing_log, finish_log = @service.infos
+
+    assert_equal 'user=42', start_log.message
+    assert_equal 'user=42', finish_log.message
+  end
+
+  def test_around_hook_timing_message_matches_milliseconds_format
+    timing_log = @service.infos[1]
+
+    assert_match(/\A\d+(?:\.\d+)?ms\z/, timing_log.message)
+  end
+
+  def test_every_hook_log_is_stamped_with_audit_source
+    sources = @service.infos.map(&:source)
+
+    assert_equal %i[audit audit audit], sources
+  end
+
+  def test_execute_body_still_returns_the_documented_result_hash
+    assert_equal({ user_id: 42 }, @service.result)
+  end
+end


### PR DESCRIPTION
## Scope

Tenth example folder from the P6-P12 plan in
[\`docs/v1/08-github-pages.md\`](https://github.com/ramongr/assistant/blob/main/docs/v1/08-github-pages.md#p6p12-examples-one-pr-per-example).
Materializes the AuditedService snippet from
[\`docs/examples/execute-callbacks.md\`](https://github.com/ramongr/assistant/blob/main/docs/examples/execute-callbacks.md)
and pins the observable hook order on the log timeline.

## Also fixes the docs snippet

The page shipped with the wrong API: \`around_execute do |cont|; cont.call\` and \`after_execute do\` (no positional arg). Neither runs. The actual contract — already documented in [\`docs/guides/composing-services.md:77\`](https://github.com/ramongr/assistant/blob/main/docs/guides/composing-services.md#L77) — is \`around_execute do |&blk|\` (continuation as the block) and \`after_execute do |result|\` (execute return value as positional arg). With the broken signatures both hooks raised \`ArgumentError\` on every call, got soft-failed via \`log_hook_error\`, and left the user with one stray log and a confusing \`:with_errors\` status. The corrected snippet now matches the canonical pattern.

## What this PR ships

- \`examples/execute_callbacks/audited_service.rb\` — \`ExecuteCallbacksExample::AuditedService\` with before/after/around hooks emitting \`:start\`, \`:finish\`, \`:timing\` info log items; around-hook preserves the inner result by capturing and returning \`blk.call\`.
- \`examples/execute_callbacks/README.md\` — problem statement, file table, observable-order explanation, manual-run incantation.
- \`test/examples/execute_callbacks_example_test.rb\` — six tests covering count, order \`%i[start timing finish]\`, \`user=42\` interpolation, the non-flaky \`/\\A\\d+(?:\\.\\d+)?ms\\z/\` timing format, shared \`:audit\` source, and the preserved \`{ user_id: 42 }\` result.
- \`docs/examples/execute-callbacks.md\` — snippet swapped to the working API; failure-semantics bullets updated to document the real signatures (around takes \`&blk\`, after takes a result arg, hook errors are soft-failed via \`source: :hook\`); closing \`{: .note }\` callout replaced with the standard Source / Test blockquote.

## Verification

- \`bundle exec rake test\` → 285 runs / 783 assertions / 0 failures (was 279 / 774 before P10). Line cov 99.65%, branch cov 92.37%.
- \`bundle exec rubocop\` → 63 files / no offenses.
- \`bundle exec steep check --jobs=1\` → no type errors.

## Out of scope

- P11 (\`instrumentation_notifier\`), P12 (\`rbs_generator\`) — each ships as its own PR per the M-numbered plan.
- B4 acceptance-criteria tick-off in \`docs/v1/08-github-pages.md\` — ships once P12 is in.