### PR TITLE
docs: materialize examples/instrumentation_notifier runnable example (P11)

### DIFF
--- a/docs/examples/instrumentation-notifier.md
+++ b/docs/examples/instrumentation-notifier.md
@@ -38,19 +38,15 @@ events.map(&:first)
 # => [:service_started, :service_validated, :service_failed]
 ```
 
-Payload shape for every event includes `service:` (the class), `id:`
-(per-run UUID), `started_at:`, plus event-specific keys (`duration_ms:`
-on `:service_executed` and `:service_failed`, `errors:` on
-`:service_failed`). See the
-[full payload table](../api-reference.md#instrumentation-notifier) for
-the exhaustive list.
+Payload shape for every event is exactly two keys: `service_class:`
+(the `Assistant::Service` subclass) and `duration_s:` (a `Float`
+seconds since `#run` started). The event set and its payload contract
+are **Frozen** for 1.0 — see the
+[full payload table](../api-reference.md#instrumentation-notifier).
 
 > **Warning** — Notifier callables are rescued from `StandardError`;
 > any exception they raise is `warn`-ed but doesn't fail the service.
 > Don't put control flow in the notifier.
 
-{: .note }
-> A runnable `examples/instrumentation_notifier/` script + integration
-> test ships in
-> [P11](https://github.com/ramongr/assistant/blob/main/docs/v1/08-github-pages.md#p6p12-examples-one-pr-per-example)
-> of the GitHub Pages plan.
+> Source: [`examples/instrumentation_notifier/`](https://github.com/ramongr/assistant/tree/main/examples/instrumentation_notifier) ·
+> Test: [`test/examples/instrumentation_notifier_example_test.rb`](https://github.com/ramongr/assistant/blob/main/test/examples/instrumentation_notifier_example_test.rb)

--- a/examples/instrumentation_notifier/README.md
+++ b/examples/instrumentation_notifier/README.md
@@ -1,0 +1,38 @@
+# Instrumentation notifier example
+
+How to wire `Assistant.notifier=` to an arbitrary callable so every
+service run dispatches the four lifecycle events (`:service_started`,
+`:service_validated`, and exactly one of `:service_executed` /
+`:service_failed`) without coupling the gem to any specific
+instrumentation backend.
+
+Companion to the
+[Instrumentation notifier docs page](../../docs/examples/instrumentation-notifier.md)
+(P11 of [`docs/v1/08-github-pages.md`](../../docs/v1/08-github-pages.md#p6p12-examples-one-pr-per-example)).
+
+## Files
+
+| File                     | Role                                                                                                            |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `create_user.rb`         | Minimal `Assistant::Service` whose happy and failure paths trigger `:service_executed` and `:service_failed`.   |
+| `notifier_example.rb`    | Installs a capturing-array notifier, runs the service twice, returns the recorded `[event, payload]` tuples.    |
+| `../../test/examples/instrumentation_notifier_example_test.rb` | Pins the event sequence on both paths and the `:service_class` / `:duration_s` payload contract. |
+
+## What the test pins
+
+* Happy path emits exactly `%i[service_started service_validated service_executed]`.
+* Failure path (`email: nil`) emits exactly `%i[service_started service_validated service_failed]` — the validator logs the error before `#execute`, so `:service_validated` still fires.
+* Every payload carries `service_class:` (the `CreateUser` class) and `duration_s:` (a non-negative `Float`). No `:errors`, no `:id`, no `:started_at` — the
+  frozen-for-1.0 payload contract is exactly those two keys, per
+  [`docs/api-reference.md#instrumentation-notifier`](../../docs/api-reference.md#instrumentation-notifier).
+* A notifier callable that raises `StandardError` does not propagate; the run still completes and the gem warns to `$stderr` instead.
+* `Assistant.notifier = nil` in `ensure` restores the no-op default so subsequent runs (and other tests) start from a clean slate.
+
+## Run it
+
+```sh
+bundle exec ruby -Ilib -rexamples/instrumentation_notifier/notifier_example -e \
+  'pp InstrumentationNotifierExample::NotifierExample.run'
+```
+
+Prints both event sequences and the payload keys.

--- a/examples/instrumentation_notifier/create_user.rb
+++ b/examples/instrumentation_notifier/create_user.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'assistant'
+
+# P11 of the GitHub Pages plan in docs/v1/08-github-pages.md. Companion
+# to docs/examples/instrumentation-notifier.md.
+module InstrumentationNotifierExample
+  # Minimal service whose runs are observed by `Assistant.notifier`.
+  # Designed to exercise both terminal events:
+  #
+  # * Happy path (`email:` and `name:` valid) -> :service_started ->
+  #   :service_validated -> :service_executed.
+  # * Failure path (`email: nil`) -> :service_started ->
+  #   :service_validated -> :service_failed, because the required-email
+  #   validator logs an error before `#execute` is invoked.
+  class CreateUser < Assistant::Service
+    input :email, type: String, required: true
+    input :name, type: String, required: true
+
+    def execute
+      add_log(level: :error, source: :validate, detail: :email, message: 'must contain @') unless email.include?('@')
+      { id: 42, email:, name: } if errors.empty?
+    end
+  end
+end

--- a/examples/instrumentation_notifier/notifier_example.rb
+++ b/examples/instrumentation_notifier/notifier_example.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require_relative 'create_user'
+
+# Two-level nesting (rather than the cop-preferred compact form) is
+# deliberate: it keeps `CreateUser` resolving via `Module.nesting` to
+# the sibling `InstrumentationNotifierExample::CreateUser` and out of
+# reach of any top-level `CreateUser` constant other example folders
+# (e.g. `examples/sidekiq_worker/create_user_worker.rb`) install when
+# they get loaded earlier in the same process.
+# rubocop:disable Style/CompactModuleNesting
+module InstrumentationNotifierExample
+  # Module-level driver invoked by the integration test and by the
+  # README's manual-run incantation. Returns the captured event tuples
+  # from both the happy and failure paths so callers can inspect them
+  # without globally configuring a notifier. Demonstrates the
+  # `Assistant.notifier=` contract documented at
+  # docs/examples/instrumentation-notifier.md.
+  module NotifierExample
+    # Run `CreateUser` once on the happy path and once on the failure
+    # path with a stub notifier installed. Returns
+    # `{ ok: Array, failed: Array }` where each value is a list of
+    # `[event_symbol, payload_hash]` tuples in dispatch order.
+    #
+    # The notifier is reset to the gem default in an `ensure` so the
+    # process-wide configuration is never left dirty.
+    def self.run
+      events = []
+      Assistant.notifier = ->(event, payload) { events << [event, payload] }
+
+      CreateUser.run(email: 'a@b.com', name: 'Alice')
+      ok = events.dup
+
+      events.clear
+      CreateUser.run(email: nil, name: 'Alice')
+      failed = events.dup
+
+      { ok: ok, failed: failed }
+    ensure
+      Assistant.notifier = nil
+    end
+  end
+end
+# rubocop:enable Style/CompactModuleNesting

--- a/test/examples/instrumentation_notifier_example_test.rb
+++ b/test/examples/instrumentation_notifier_example_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require_relative 'test_helper'
+require File.join(ExampleTestHelpers::EXAMPLES_ROOT, 'instrumentation_notifier/notifier_example')
+
+# Pins the lifecycle event sequence and payload contract documented at
+# docs/examples/instrumentation-notifier.md. Every test resets
+# `Assistant.notifier` in `ensure` so the gem-wide singleton never
+# leaks across the file (or into sibling test suites that depend on
+# the default no-op notifier).
+class InstrumentationNotifierExampleTest < Minitest::Test
+  include TestHelpers::IoCapture
+
+  def teardown
+    Assistant.notifier = nil
+  end
+
+  def test_happy_path_emits_started_validated_executed_in_order
+    captured = InstrumentationNotifierExample::NotifierExample.run
+
+    assert_equal %i[service_started service_validated service_executed], captured[:ok].map(&:first)
+  end
+
+  def test_failure_path_emits_started_validated_failed_in_order
+    captured = InstrumentationNotifierExample::NotifierExample.run
+
+    assert_equal %i[service_started service_validated service_failed], captured[:failed].map(&:first)
+  end
+
+  def test_every_payload_includes_service_class_and_duration_s
+    captured = InstrumentationNotifierExample::NotifierExample.run
+    payloads = captured[:ok].map(&:last) + captured[:failed].map(&:last)
+
+    assert(payloads.all? { |p| p[:service_class] == InstrumentationNotifierExample::CreateUser })
+    assert(payloads.all? { |p| p[:duration_s].is_a?(Float) && p[:duration_s] >= 0 })
+  end
+
+  def test_payload_carries_exactly_service_class_and_duration_s
+    captured = InstrumentationNotifierExample::NotifierExample.run
+
+    assert_equal %i[service_class duration_s].sort, captured[:ok].first.last.keys.sort
+  end
+
+  def test_notifier_exception_is_warn_logged_not_raised
+    Assistant.notifier = ->(_event, _payload) { raise 'boom' }
+    stderr = capture_io_warn do
+      payload = InstrumentationNotifierExample::CreateUser.run(email: 'a@b.com', name: 'Ada')
+
+      assert_equal :ok, payload[:status]
+    end
+
+    assert_match(/notifier raised during service_started/, stderr)
+  end
+end


### PR DESCRIPTION
## Scope

Eleventh example folder from the P6-P12 plan in
[docs/v1/08-github-pages.md](https://github.com/ramongr/assistant/blob/main/docs/v1/08-github-pages.md#p6p12-examples-one-pr-per-example).
Materializes the \`Assistant.notifier=\` walkthrough at
[docs/examples/instrumentation-notifier.md](https://github.com/ramongr/assistant/blob/main/docs/examples/instrumentation-notifier.md)
and corrects the page's payload contract, which had drifted from
the Frozen-for-1.0 reference at
[docs/api-reference.md#instrumentation-notifier](https://github.com/ramongr/assistant/blob/main/docs/api-reference.md#instrumentation-notifier).

## What this PR ships

- \`examples/instrumentation_notifier/create_user.rb\` -- minimal Service with \`email\` / \`name\` String inputs whose failure path (\`email: nil\`) is caught by the \`required:\` validator, so \`:service_validated\` fires before \`:service_failed\`.
- \`examples/instrumentation_notifier/notifier_example.rb\` -- module-level \`.run\` driver that installs a capturing notifier, runs CreateUser once happy and once failing, returns \`{ ok:, failed: }\` with the captured \`[event, payload]\` tuples in dispatch order, and resets \`Assistant.notifier = nil\` in an \`ensure\` block.
- \`examples/instrumentation_notifier/README.md\` -- problem statement, file table, 'what the test pins' bullets, manual-run incantation.
- \`test/examples/instrumentation_notifier_example_test.rb\` -- five tests covering happy/failure event sequences, payload shape, and the \`'assistant: notifier raised during ...'\` rescue path. Uses the existing \`TestHelpers::IoCapture\` mixin.
- \`docs/examples/instrumentation-notifier.md\` -- payload contract fix + closing \`{: .note }\` swapped for the standard \`> Source: ... . Test: ...\` blockquote.

## Why the page needed correcting

The page promised payload keys \`service:\`, \`id:\`, \`started_at:\`, \`duration_ms:\`, \`errors:\`. The actual contract in \`lib/assistant/service.rb#dispatch_lifecycle\` -- and pinned by the new test -- is exactly two keys: \`service_class:\` (the Service subclass) and \`duration_s:\` (a Float). Anyone who wired a notifier expecting the documented keys would have hit \`KeyError\` on the first event. The corrected paragraph now refers readers to the curated reference for the authoritative contract.

## Why two-level nesting in \`notifier_example.rb\`

Rubocop's \`Style/CompactModuleNesting\` wants \`module InstrumentationNotifierExample::NotifierExample\`, but the compact form changes \`Module.nesting\` so the bare \`CreateUser\` constant inside \`#run\` no longer resolves to the sibling \`InstrumentationNotifierExample::CreateUser\`. When Minitest loads sibling example folders earlier in the same process (notably \`examples/sidekiq_worker/create_user_worker.rb\`, which installs a top-level \`CreateUser\` constant), the compact-form lookup would resolve to the wrong class and explode with \`NoMethodError\`. Keeping the nested form -- with the cop disabled inline and the rationale documented in a leading comment -- avoids the foot-gun.

## Verification

- \`bundle exec rake test\` -> 290 runs / 791 assertions / 0 failures / 0 errors. Line cov 99.66%, branch cov 90.98% (was 285 / 783 after P10).
- \`bundle exec rubocop\` -> 66 files / no offenses.
- \`bundle exec steep check --jobs=1\` -> no type errors.

## Out of scope

- P12 (\`rbs_generator\`) -- ships as its own PR.
- B4 acceptance-criteria tick-off in \`docs/v1/08-github-pages.md\` -- ships once P12 is in.