### PR TITLE
docs: pin sidebar toggle to top

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -76,7 +76,12 @@
       margin: 0 0 1rem;
       text-align: center;
     }
-    .sidebar-toggle { background-color: transparent; }
+    .sidebar-toggle {
+      background-color: transparent;
+      bottom: auto;
+      top: 0;
+      width: auto;
+    }
   </style>
 </head>
 <body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -75,7 +75,12 @@
       margin-bottom: 3.125rem !important;
       text-align: center;
     }
-    .sidebar-toggle { background-color: transparent; }
+    .sidebar-toggle {
+      background-color: transparent;
+      bottom: auto;
+      top: 0;
+      width: auto;
+    }
   </style>
 </head>
 <body>

--- a/test/docs/docsify_shell_test.rb
+++ b/test/docs/docsify_shell_test.rb
@@ -24,6 +24,9 @@ class DocsifyShellTest < Minitest::Test
       assert_includes html, "nameLink: '#/'", shell
       assert_includes html, "basePath: '/assistant/'", shell
       assert_includes html, "'/.*/_sidebar.md': '/_sidebar.md'", shell
+      assert_includes html, 'bottom: auto;', shell
+      assert_includes html, 'top: 0;', shell
+      assert_includes html, 'width: auto;', shell
     end
   end
 end


### PR DESCRIPTION
**Scope**

Small docs shell fix for the Docsify sidenav toggle placement.

**What this PR ships**

- Overrides Docsify's default lower-left `.sidebar-toggle` placement in both docs shells.
- Pins the toggle to the top-left of the viewport with `bottom: auto`, `top: 0`, and `width: auto`.
- Extends the Docsify shell regression test to cover the shared toggle CSS.

**Sample output / behavior**

```css
.sidebar-toggle {
  background-color: transparent;
  bottom: auto;
  top: 0;
  width: auto;
}
```

**Verification**

```text
bundle exec ruby -Itest test/docs/docsify_shell_test.rb
2 runs, 34 assertions, 0 failures, 0 errors, 0 skips
```

```text
bundle exec rake test
295 runs, 837 assertions, 0 failures, 0 errors, 0 skips
```

```text
bundle exec rubocop
71 files inspected, no offenses detected
```

```text
bundle exec steep check --jobs=1
No type error detected.
```

**Out of scope**

- No Docsify routing, sidebar content, or branding changes beyond the toggle placement.