### PR TITLE
docs: refine sidebar toggle states

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -47,8 +47,10 @@
                                      theme color — 7.87:1 on #f4f2f3,
                                      8.30:1 on #ffffff, both AAA)
          #f4f2f3 — Cultured         (light background)
-         #ffd166 — Naples Yellow    (primary accent in dark mode only) */
+         #ffd166 — Naples Yellow    (primary accent) */
       --theme-color: #2f4f5a;
+      --assistant-space-cadet: #22223b;
+      --assistant-naples-yellow: #ffd166;
     }
     .app-name-link {
       align-items: center;
@@ -81,12 +83,12 @@
     }
     body.assistant-sidebar-shell .sidebar-toggle {
       align-items: center;
-      background: rgba(34, 34, 59, 0.94);
-      border: 1px solid rgba(255, 209, 102, 0.34);
+      background: var(--assistant-space-cadet);
+      border: 1px solid rgba(255, 209, 102, 0.42);
       border-radius: 999px;
       bottom: auto;
       box-shadow: 0 10px 30px rgba(0, 0, 0, 0.24);
-      color: #ffd166;
+      color: var(--assistant-naples-yellow);
       display: flex;
       height: 2.25rem;
       justify-content: center;
@@ -99,9 +101,9 @@
       z-index: 60;
     }
     body.assistant-sidebar-shell .sidebar-toggle:hover {
-      background: #ffd166;
-      border-color: #ffd166;
-      color: #22223b;
+      background: var(--assistant-naples-yellow);
+      border-color: var(--assistant-naples-yellow);
+      color: var(--assistant-space-cadet);
       transform: translateY(-1px);
     }
     body.assistant-sidebar-shell .sidebar-toggle span {
@@ -115,9 +117,14 @@
       transform: translateY(-0.08em);
     }
     body.assistant-sidebar-shell.close .sidebar-toggle {
-      background: rgba(244, 242, 243, 0.94);
-      border-color: rgba(47, 79, 90, 0.2);
-      color: #2f4f5a;
+      background: var(--assistant-naples-yellow);
+      border-color: var(--assistant-naples-yellow);
+      color: var(--assistant-space-cadet);
+    }
+    body.assistant-sidebar-shell.close .sidebar-toggle:hover {
+      background: var(--assistant-space-cadet);
+      border-color: var(--assistant-space-cadet);
+      color: var(--assistant-naples-yellow);
     }
     body.assistant-sidebar-shell.close .sidebar-toggle::before {
       content: "\2630";

--- a/docs/404.html
+++ b/docs/404.html
@@ -76,15 +76,57 @@
       margin: 0 0 1rem;
       text-align: center;
     }
-    .sidebar-toggle {
-      background-color: transparent;
+    body.assistant-sidebar-shell .sidebar {
+      padding-top: 4rem;
+    }
+    body.assistant-sidebar-shell .sidebar-toggle {
+      align-items: center;
+      background: rgba(34, 34, 59, 0.94);
+      border: 1px solid rgba(255, 209, 102, 0.34);
+      border-radius: 999px;
       bottom: auto;
-      top: 0;
-      width: auto;
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.24);
+      color: #ffd166;
+      display: flex;
+      height: 2.25rem;
+      justify-content: center;
+      left: 0.875rem;
+      padding: 0;
+      top: 0.875rem;
+      transition: background-color 0.2s ease, border-color 0.2s ease,
+        color 0.2s ease, transform 0.2s ease;
+      width: 2.25rem;
+      z-index: 60;
+    }
+    body.assistant-sidebar-shell .sidebar-toggle:hover {
+      background: #ffd166;
+      border-color: #ffd166;
+      color: #22223b;
+      transform: translateY(-1px);
+    }
+    body.assistant-sidebar-shell .sidebar-toggle span {
+      display: none;
+    }
+    body.assistant-sidebar-shell .sidebar-toggle::before {
+      content: "\00d7";
+      font-size: 1.75rem;
+      font-weight: 700;
+      line-height: 1;
+      transform: translateY(-0.08em);
+    }
+    body.assistant-sidebar-shell.close .sidebar-toggle {
+      background: rgba(244, 242, 243, 0.94);
+      border-color: rgba(47, 79, 90, 0.2);
+      color: #2f4f5a;
+    }
+    body.assistant-sidebar-shell.close .sidebar-toggle::before {
+      content: "\2630";
+      font-size: 1.25rem;
+      transform: none;
     }
   </style>
 </head>
-<body>
+<body class="assistant-sidebar-shell">
   <div id="app">Loading documentation&hellip;</div>
 
   <script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -47,8 +47,10 @@
                                      theme color — 7.87:1 on #f4f2f3,
                                      8.30:1 on #ffffff, both AAA)
          #f4f2f3 — Cultured         (light background)
-         #ffd166 — Naples Yellow    (primary accent in dark mode only) */
+         #ffd166 — Naples Yellow    (primary accent) */
       --theme-color: #2f4f5a;
+      --assistant-space-cadet: #22223b;
+      --assistant-naples-yellow: #ffd166;
     }
     .app-name-link {
       align-items: center;
@@ -80,12 +82,12 @@
     }
     body.assistant-sidebar-shell .sidebar-toggle {
       align-items: center;
-      background: rgba(34, 34, 59, 0.94);
-      border: 1px solid rgba(255, 209, 102, 0.34);
+      background: var(--assistant-space-cadet);
+      border: 1px solid rgba(255, 209, 102, 0.42);
       border-radius: 999px;
       bottom: auto;
       box-shadow: 0 10px 30px rgba(0, 0, 0, 0.24);
-      color: #ffd166;
+      color: var(--assistant-naples-yellow);
       display: flex;
       height: 2.25rem;
       justify-content: center;
@@ -98,9 +100,9 @@
       z-index: 60;
     }
     body.assistant-sidebar-shell .sidebar-toggle:hover {
-      background: #ffd166;
-      border-color: #ffd166;
-      color: #22223b;
+      background: var(--assistant-naples-yellow);
+      border-color: var(--assistant-naples-yellow);
+      color: var(--assistant-space-cadet);
       transform: translateY(-1px);
     }
     body.assistant-sidebar-shell .sidebar-toggle span {
@@ -114,9 +116,14 @@
       transform: translateY(-0.08em);
     }
     body.assistant-sidebar-shell.close .sidebar-toggle {
-      background: rgba(244, 242, 243, 0.94);
-      border-color: rgba(47, 79, 90, 0.2);
-      color: #2f4f5a;
+      background: var(--assistant-naples-yellow);
+      border-color: var(--assistant-naples-yellow);
+      color: var(--assistant-space-cadet);
+    }
+    body.assistant-sidebar-shell.close .sidebar-toggle:hover {
+      background: var(--assistant-space-cadet);
+      border-color: var(--assistant-space-cadet);
+      color: var(--assistant-naples-yellow);
     }
     body.assistant-sidebar-shell.close .sidebar-toggle::before {
       content: "\2630";

--- a/docs/index.html
+++ b/docs/index.html
@@ -75,15 +75,57 @@
       margin-bottom: 3.125rem !important;
       text-align: center;
     }
-    .sidebar-toggle {
-      background-color: transparent;
+    body.assistant-sidebar-shell .sidebar {
+      padding-top: 4rem;
+    }
+    body.assistant-sidebar-shell .sidebar-toggle {
+      align-items: center;
+      background: rgba(34, 34, 59, 0.94);
+      border: 1px solid rgba(255, 209, 102, 0.34);
+      border-radius: 999px;
       bottom: auto;
-      top: 0;
-      width: auto;
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.24);
+      color: #ffd166;
+      display: flex;
+      height: 2.25rem;
+      justify-content: center;
+      left: 0.875rem;
+      padding: 0;
+      top: 0.875rem;
+      transition: background-color 0.2s ease, border-color 0.2s ease,
+        color 0.2s ease, transform 0.2s ease;
+      width: 2.25rem;
+      z-index: 60;
+    }
+    body.assistant-sidebar-shell .sidebar-toggle:hover {
+      background: #ffd166;
+      border-color: #ffd166;
+      color: #22223b;
+      transform: translateY(-1px);
+    }
+    body.assistant-sidebar-shell .sidebar-toggle span {
+      display: none;
+    }
+    body.assistant-sidebar-shell .sidebar-toggle::before {
+      content: "\00d7";
+      font-size: 1.75rem;
+      font-weight: 700;
+      line-height: 1;
+      transform: translateY(-0.08em);
+    }
+    body.assistant-sidebar-shell.close .sidebar-toggle {
+      background: rgba(244, 242, 243, 0.94);
+      border-color: rgba(47, 79, 90, 0.2);
+      color: #2f4f5a;
+    }
+    body.assistant-sidebar-shell.close .sidebar-toggle::before {
+      content: "\2630";
+      font-size: 1.25rem;
+      transform: none;
     }
   </style>
 </head>
-<body>
+<body class="assistant-sidebar-shell">
   <div id="app">Loading documentation&hellip;</div>
 
   <script>

--- a/test/docs/docsify_shell_test.rb
+++ b/test/docs/docsify_shell_test.rb
@@ -24,9 +24,20 @@ class DocsifyShellTest < Minitest::Test
       assert_includes html, "nameLink: '#/'", shell
       assert_includes html, "basePath: '/assistant/'", shell
       assert_includes html, "'/.*/_sidebar.md': '/_sidebar.md'", shell
+    end
+  end
+
+  def test_docsify_shells_style_sidebar_toggle_states
+    SHELLS.each do |shell|
+      html = File.read(shell)
+
+      assert_includes html, '<body class="assistant-sidebar-shell">', shell
+      assert_includes html, 'body.assistant-sidebar-shell .sidebar {', shell
       assert_includes html, 'bottom: auto;', shell
-      assert_includes html, 'top: 0;', shell
-      assert_includes html, 'width: auto;', shell
+      assert_includes html, 'top: 0.875rem;', shell
+      assert_includes html, 'content: "\\00d7";', shell
+      assert_includes html, 'body.assistant-sidebar-shell.close .sidebar-toggle::before', shell
+      assert_includes html, 'content: "\\2630";', shell
     end
   end
 end

--- a/test/docs/docsify_shell_test.rb
+++ b/test/docs/docsify_shell_test.rb
@@ -40,4 +40,17 @@ class DocsifyShellTest < Minitest::Test
       assert_includes html, 'content: "\\2630";', shell
     end
   end
+
+  def test_docsify_shells_keep_sidebar_toggle_palette_mode_neutral
+    SHELLS.each do |shell|
+      html = File.read(shell)
+
+      assert_includes html, '--assistant-space-cadet: #22223b;', shell
+      assert_includes html, '--assistant-naples-yellow: #ffd166;', shell
+      assert_includes html, 'background: var(--assistant-space-cadet);', shell
+      assert_includes html, 'color: var(--assistant-naples-yellow);', shell
+      assert_includes html, 'background: var(--assistant-naples-yellow);', shell
+      assert_includes html, 'color: var(--assistant-space-cadet);', shell
+    end
+  end
 end


### PR DESCRIPTION
**Scope**

Follow-up docs shell polish for the Docsify sidebar toggle after #204 moved the sidenav button to the top-left.

**What this PR ships**

- Styles the Docsify sidebar toggle as a compact circular top-left control.
- Uses different icons for the expanded and collapsed sidebar states.
- Adds top padding to the sidebar so search/navigation do not collide with the toggle.
- Covers the shared Docsify shell CSS with regression assertions.

**Sample output / behavior**

```text
Expanded sidebar: top-left × close control
Collapsed sidebar: top-left ☰ open control
```

**Verification**

```text
bundle exec rake test
296 runs, 853 assertions, 0 failures, 0 errors, 0 skips
```

```text
bundle exec rubocop
71 files inspected, no offenses detected
```

```text
bundle exec steep check --jobs=1
No type error detected.
```

**Out of scope**

No broader Docsify theme restructuring or JavaScript behavior changes.